### PR TITLE
chore: QueryDSL 세팅한다.

### DIFF
--- a/anifriends/.gitignore
+++ b/anifriends/.gitignore
@@ -37,3 +37,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QueryDSL ###
+/src/main/generated

--- a/anifriends/build.gradle
+++ b/anifriends/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.5'
@@ -44,6 +50,12 @@ dependencies {
 	//RestDocs
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+	//querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
@@ -82,3 +94,21 @@ build {
 	dependsOn copyDocument
 }
 //RestDocs end
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
+}


### PR DESCRIPTION
### ⛏ 작업 사항
QueryDSL 세팅

### 📝 작업 요약
- `build.gradle` 에 queryDSL 설정을 위한 코드 추가
- `.gitignore`에 `/src/main/generated` 추가함으로써 Q 클래스 원격 저장소에 올라가지 못하게 함

### 💡 관련 이슈
- close #9 
