### PR TITLE
chore: 공통 예외 클래스를 정의한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/global/exception/AuthenticationException.java
+++ b/src/main/java/com/clova/anifriends/global/exception/AuthenticationException.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.global.exception;
+
+public abstract class AuthenticationException extends RuntimeException {
+
+    protected AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/exception/AuthorizationException.java
+++ b/src/main/java/com/clova/anifriends/global/exception/AuthorizationException.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.global.exception;
+
+public abstract class AuthorizationException extends RuntimeException {
+
+    protected AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/exception/BadRequestException.java
+++ b/src/main/java/com/clova/anifriends/global/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.global.exception;
+
+public abstract class BadRequestException extends RuntimeException{
+
+    protected BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/exception/ConflictException.java
+++ b/src/main/java/com/clova/anifriends/global/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.global.exception;
+
+public abstract class ConflictException extends RuntimeException {
+
+    protected ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/exception/ErrorResponse.java
+++ b/src/main/java/com/clova/anifriends/global/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.clova.anifriends.global.exception;
+
+public record ErrorResponse(String message) {
+
+}

--- a/src/main/java/com/clova/anifriends/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clova/anifriends/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.clova.anifriends.global.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> badRequestEx(BadRequestException e) {
+        return ResponseEntity.status(BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> authenticationEx(AuthenticationException e) {
+        return ResponseEntity.status(UNAUTHORIZED).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ErrorResponse> authorizationEx(AuthorizationException e) {
+        return ResponseEntity.status(FORBIDDEN).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> notFoundEx(NotFoundException e) {
+        return ResponseEntity.status(NOT_FOUND).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> conflictEx(ConflictException e) {
+        return ResponseEntity.status(CONFLICT).body(new ErrorResponse(e.getMessage()));
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/exception/NotFoundException.java
+++ b/src/main/java/com/clova/anifriends/global/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.global.exception;
+
+public abstract class NotFoundException extends RuntimeException {
+
+    protected NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/clova/anifriends/global/exception/ExceptionController.java
+++ b/src/test/java/com/clova/anifriends/global/exception/ExceptionController.java
@@ -1,0 +1,60 @@
+package com.clova.anifriends.global.exception;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class ExceptionController {
+
+    @GetMapping("/bad-request")
+    public void badRequest() {
+        throw new BadRequestException("bad-request") {
+            @Override
+            public String getMessage() {
+                return super.getMessage();
+            }
+        };
+    }
+
+    @GetMapping("/authentication")
+    public void authentication() {
+        throw new AuthenticationException("authentication") {
+            @Override
+            public String getMessage() {
+                return super.getMessage();
+            }
+        };
+    }
+
+    @GetMapping("/authorization")
+    public void authorization() {
+        throw new AuthorizationException("authorization") {
+            @Override
+            public String getMessage() {
+                return super.getMessage();
+            }
+        };
+    }
+
+    @GetMapping("/not-found")
+    public void notFound() {
+        throw new NotFoundException("notFound") {
+            @Override
+            public String getMessage() {
+                return super.getMessage();
+            }
+        };
+    }
+
+    @GetMapping("/conflict")
+    public void conflict() {
+        throw new ConflictException("conflict") {
+            @Override
+            public String getMessage() {
+                return super.getMessage();
+            }
+        };
+    }
+}

--- a/src/test/java/com/clova/anifriends/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/clova/anifriends/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+package com.clova.anifriends.global.exception;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.clova.anifriends.base.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+
+class GlobalExceptionHandlerTest extends BaseControllerTest {
+
+    @Nested
+    @DisplayName("BadRequestException 발생 시")
+    class ThrowBadRequestExceptionTest {
+
+        @Test
+        @DisplayName("성공: 상태 코드 400 반환")
+        void return400() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/test/bad-request"));
+
+            //then
+            resultActions.andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("AuthenticationException 발생 시")
+    class ThrowAuthenticationExceptionTest {
+
+        @Test
+        @DisplayName("성공: 상태 코드 401 반환")
+        void return401() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/test/authentication"));
+
+            //then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("AuthorizationException 발생 시")
+    class ThrowAuthorizationExceptionTest {
+
+        @Test
+        @DisplayName("성공: 상태 코드 403 반환")
+        void return403() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/test/authorization"));
+
+            //then
+            resultActions.andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("NotFoundException 발생 시")
+    class ThrowNotFoundExceptionTest {
+
+        @Test
+        @DisplayName("성공: 상태 코드 404 반환")
+        void return404() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/test/not-found"));
+
+            //then
+            resultActions.andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("ConflictException 발생 시")
+    class ThrowConflictExceptionTest {
+
+        @Test
+        @DisplayName("성공: 상태 코드 409 반환")
+        void return409() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/test/conflict"));
+
+            //then
+            resultActions.andExpect(status().isConflict());
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 공통 예외 클래스를 정의하였습니다.
  - 400 : `BadRequestExcpetion`
  - 401 : `AuthenticationException`
  - 403 : `AuthorizationException`
  - 404: `NotFoundException`
  - 409: `ConflictException` 
- 공통 예외 클래스를 처리하는 예외 핸들러를 추가하였습니다.


### 📝 작업 요약
- 400번대 상태 코드에 해당하는 예외 클래스 추가
- 이들 예외를 처리하는 `GlobalExceptionHandler` 추가


### 💡 관련 이슈
- close #17 
