### PR TITLE
feat: 마이페이지 조회 로직을 구현한다. (보호소)

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
@@ -1,6 +1,8 @@
 package com.clova.anifriends.domain.shelter.controller;
 
+import com.clova.anifriends.domain.auth.resolver.LoginUser;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
+import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.service.ShelterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,16 @@ public class ShelterController {
     ) {
         return ResponseEntity.ok()
             .body(shelterService.findShelterDetail(
+                shelterId
+            ));
+    }
+
+    @GetMapping("/shelters/me")
+    public ResponseEntity<FindShelterMyPageResponse> findShelterMyPage(
+        @LoginUser Long shelterId
+    ) {
+        return ResponseEntity.ok()
+            .body(shelterService.findShelterMyPageResponse(
                 shelterId
             ));
     }

--- a/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
@@ -33,7 +33,7 @@ public class ShelterController {
         @LoginUser Long shelterId
     ) {
         return ResponseEntity.ok()
-            .body(shelterService.findShelterMyPageResponse(
+            .body(shelterService.findShelterMyPage(
                 shelterId
             ));
     }

--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/FindShelterMyPageResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/FindShelterMyPageResponse.java
@@ -1,0 +1,30 @@
+package com.clova.anifriends.domain.shelter.dto;
+
+import com.clova.anifriends.domain.shelter.Shelter;
+
+public record FindShelterMyPageResponse(
+    Long shelterId,
+    String name,
+    String address,
+    String addressDetail,
+    boolean isOpenedAddress,
+    String phoneNumber,
+    String sparePhoneNumber,
+    String imageUrl
+) {
+
+    public static FindShelterMyPageResponse from(
+        Shelter shelter
+    ) {
+        return new FindShelterMyPageResponse(
+            shelter.getShelterId(),
+            shelter.getName(),
+            shelter.getAddress(),
+            shelter.getAddressDetail(),
+            shelter.isOpenedAddress(),
+            shelter.getPhoneNumber(),
+            shelter.getSparePhoneNumber(),
+            shelter.getShelterImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
@@ -32,7 +32,7 @@ public class ShelterService {
     }
 
     @Transactional(readOnly = true)
-    public FindShelterMyPageResponse findShelterMyPageResponse(
+    public FindShelterMyPageResponse findShelterMyPage(
         Long shelterId
     ) {
         Shelter foundShelter = getShelter(shelterId);

--- a/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.shelter.service;
 
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
+import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.global.exception.ErrorCode;
@@ -19,12 +20,23 @@ public class ShelterService {
     public FindShelterDetailResponse findShelterDetail(
         Long shelterId
     ) {
-        Shelter foundShelter = shelterRepository.findById(shelterId)
+        Shelter foundShelter = getShelter(shelterId);
+
+        return FindShelterDetailResponse.from(foundShelter);
+    }
+
+    private Shelter getShelter(Long shelterId) {
+        return shelterRepository.findById(shelterId)
             .orElseThrow(
                 () -> new ShelterNotFoundException(ErrorCode.NOT_FOUND, "존재하지 않는 보호소입니다."));
+    }
 
-        return FindShelterDetailResponse.from(
-            foundShelter
-        );
+    @Transactional(readOnly = true)
+    public FindShelterMyPageResponse findShelterMyPageResponse(
+        Long shelterId
+    ) {
+        Shelter foundShelter = getShelter(shelterId);
+
+        return FindShelterMyPageResponse.from(foundShelter);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/shelter/wrapper/ShelterName.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/wrapper/ShelterName.java
@@ -6,6 +6,7 @@ import com.clova.anifriends.domain.shelter.exception.ShelterBadRequestException;
 import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.text.MessageFormat;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,7 +32,8 @@ public class ShelterName {
         }
 
         if (name.length() > MAX_SHELTER_NAME_LENGTH) {
-            throw new ShelterBadRequestException(ErrorCode.BAD_REQUEST, "이름은 최대 10자입니다.");
+            throw new ShelterBadRequestException(ErrorCode.BAD_REQUEST,
+                MessageFormat.format("이름은 최대 {0}입니다.", MAX_SHELTER_NAME_LENGTH));
         }
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/shelter/wrapper/ShelterPassword.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/wrapper/ShelterPassword.java
@@ -6,6 +6,7 @@ import com.clova.anifriends.domain.shelter.exception.ShelterBadRequestException;
 import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.text.MessageFormat;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,7 +34,8 @@ public class ShelterPassword {
 
         if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
             throw new ShelterBadRequestException(ErrorCode.BAD_REQUEST,
-                "비밀번호는 최소 6자, 최대 16자입니다.");
+                MessageFormat.format("이름은 최소 {0}자, 최대 {1}자 입니다.", MIN_PASSWORD_LENGTH,
+                    MAX_PASSWORD_LENGTH));
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
@@ -9,11 +9,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 import com.clova.anifriends.base.BaseControllerTest.WebMvcTestConfig;
 import com.clova.anifriends.base.config.RestDocsConfig;
-import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
 import com.clova.anifriends.domain.auth.authentication.JwtAuthenticationProvider;
 import com.clova.anifriends.domain.auth.jwt.JwtProvider;
 import com.clova.anifriends.domain.auth.service.AuthService;
 import com.clova.anifriends.domain.auth.support.AuthFixture;
+import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
 import com.clova.anifriends.domain.shelter.service.ShelterService;
 import com.clova.anifriends.domain.volunteer.service.VolunteerService;
 import com.clova.anifriends.global.config.SecurityConfig;
@@ -87,6 +87,8 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected ShelterService shelterService;
+
+    protected final String shelterAccessToken = AuthFixture.shelterAccessToken();
 
     @BeforeEach
     void setUp(

--- a/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
@@ -87,7 +87,8 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected ShelterService shelterService;
-    
+
+    protected final String volunteerAccessToken = AuthFixture.volunteerAccessToken();
     protected final String shelterAccessToken = AuthFixture.shelterAccessToken();
 
     @BeforeEach

--- a/src/test/java/com/clova/anifriends/domain/auth/resolver/LoginUserArgumentResolverTest.java
+++ b/src/test/java/com/clova/anifriends/domain/auth/resolver/LoginUserArgumentResolverTest.java
@@ -20,7 +20,7 @@ class LoginUserArgumentResolverTest extends BaseControllerTest {
     @DisplayName("@LoginUser를 사용하는 경우")
     class LoginUserTest {
 
-        String accessToken = AuthFixture.accessToken();
+        String accessToken = AuthFixture.shelterAccessToken();
 
         @Test
         @DisplayName("성공: 액세스 토큰이 포함되어 있으면")

--- a/src/test/java/com/clova/anifriends/domain/auth/support/AuthFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/auth/support/AuthFixture.java
@@ -13,8 +13,6 @@ public final class AuthFixture {
     private static final String TEST_SECRET = "}:ASV~lS,%!I:ba^GBR<Q@cJN~!,Y0=zx7Rqwum+remZ>ayhI3$4dX$jx~@9[1F";
     private static final String TEST_REFRESH_SECRET = "~GWW.|?:\"#Rqmm^-nk#>#4Ngc}]3xz!hOQCXNF:8z-Mdn\"U!Vt</+/8;ATR*lc{";
     private static final Long USER_ID = 1L;
-    private static final UserRole ROLE_VOLUNTEER = UserRole.ROLE_VOLUNTEER;
-
 
     public static JwtProvider jwtProvider() {
         return jJwtProvider();
@@ -25,8 +23,8 @@ public final class AuthFixture {
             TEST_REFRESH_SECRET);
     }
 
-    public static String accessToken() {
-        UserToken userToken = jwtProvider().createToken(USER_ID, UserRole.ROLE_VOLUNTEER);
+    public static String shelterAccessToken() {
+        UserToken userToken = jwtProvider().createToken(USER_ID, UserRole.ROLE_SHELTER);
         return userToken.accessToken();
     }
 

--- a/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
@@ -106,7 +106,7 @@ class ShelterControllerTest extends BaseControllerTest {
             shelter.getShelterImageUrl()
         );
 
-        given(shelterService.findShelterMyPageResponse(shelterId)).willReturn(
+        given(shelterService.findShelterMyPage(shelterId)).willReturn(
             findShelterMyPageResponse);
 
         // when

--- a/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
@@ -12,6 +12,7 @@ import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.ShelterImage;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
+import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.shelter.support.ShelterImageFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +32,7 @@ class ShelterControllerTest extends BaseControllerTest {
         Shelter shelter = ShelterFixture.shelter();
         ReflectionTestUtils.setField(shelter, "shelterId", shelterId);
         ShelterImage shelterImage = ShelterImageFixture.shelterImage(shelter);
+        shelter.setShelterImage(shelterImage);
         FindShelterDetailResponse findShelterDetailResponse = new FindShelterDetailResponse(
             shelter.getShelterId(),
             shelter.getEmail(),
@@ -39,7 +41,7 @@ class ShelterControllerTest extends BaseControllerTest {
             shelter.getAddressDetail(),
             shelter.getPhoneNumber(),
             shelter.getSparePhoneNumber(),
-            shelterImage.getImageUrl()
+            shelter.getShelterImageUrl()
         );
 
         given(shelterService.findShelterDetail(shelterId)).willReturn(findShelterDetailResponse);
@@ -47,6 +49,7 @@ class ShelterControllerTest extends BaseControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
             get("/api/volunteers/shelters/{shelterId}/profile", shelterId)
+                .header(AUTHORIZATION, shelterAccessToken)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -70,6 +73,66 @@ class ShelterControllerTest extends BaseControllerTest {
                     fieldWithPath("addressDetail").type(
                             JsonFieldType.STRING)
                         .description("보호소 상세주소"),
+                    fieldWithPath("phoneNumber").type(
+                            JsonFieldType.STRING)
+                        .description("보호소 전화번호"),
+                    fieldWithPath("sparePhoneNumber").type(
+                            JsonFieldType.STRING)
+                        .description("보호소 임시 전화번호"),
+                    fieldWithPath("imageUrl").type(
+                            JsonFieldType.STRING)
+                        .description("보호소 이미지 Url")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("findShelterMyPage 실행 시")
+    void findShelterMyPage() throws Exception {
+        // given
+        Long shelterId = 1L;
+        Shelter shelter = ShelterFixture.shelter();
+        ReflectionTestUtils.setField(shelter, "shelterId", shelterId);
+        ShelterImage shelterImage = ShelterImageFixture.shelterImage(shelter);
+        shelter.setShelterImage(shelterImage);
+        FindShelterMyPageResponse findShelterMyPageResponse = new FindShelterMyPageResponse(
+            shelter.getShelterId(),
+            shelter.getName(),
+            shelter.getAddress(),
+            shelter.getAddressDetail(),
+            shelter.isOpenedAddress(),
+            shelter.getPhoneNumber(),
+            shelter.getSparePhoneNumber(),
+            shelter.getShelterImageUrl()
+        );
+
+        given(shelterService.findShelterMyPageResponse(shelterId)).willReturn(
+            findShelterMyPageResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            get("/api/shelters/me")
+                .header(AUTHORIZATION, shelterAccessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("shelterId").type(JsonFieldType.NUMBER)
+                        .description("보호소 ID"),
+                    fieldWithPath("name").type(
+                            JsonFieldType.STRING)
+                        .description("보호소 이름"),
+                    fieldWithPath("address").type(
+                            JsonFieldType.STRING)
+                        .description("보호소 주소"),
+                    fieldWithPath("addressDetail").type(
+                            JsonFieldType.STRING)
+                        .description("보호소 상세주소"),
+                    fieldWithPath("isOpenedAddress").type(
+                            JsonFieldType.BOOLEAN)
+                        .description("상세 주소 공개 여부"),
                     fieldWithPath("phoneNumber").type(
                             JsonFieldType.STRING)
                         .description("보호소 전화번호"),

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
@@ -9,8 +9,8 @@ import static org.mockito.BDDMockito.given;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.ShelterImage;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
+import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
-import com.clova.anifriends.domain.shelter.repository.ShelterImageRepository;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.shelter.support.ShelterImageFixture;
@@ -31,9 +31,6 @@ class ShelterServiceTest {
 
     @Mock
     private ShelterRepository shelterRepository;
-
-    @Mock
-    private ShelterImageRepository shelterImageRepository;
 
     Shelter givenShelter;
     ShelterImage givenShelterImage;
@@ -76,6 +73,50 @@ class ShelterServiceTest {
             // when
             Exception exception = catchException(
                 () -> shelterService.findShelterDetail(shelterId));
+
+            // then
+            assertThat(exception).isInstanceOf(ShelterNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("findShelterMyPage 실행 시")
+    class findShelterMyPageTest {
+
+        @Test
+        @DisplayName("성공")
+        void findShelterMyPage() {
+            //given
+            givenShelter = ShelterFixture.shelter();
+            givenShelterImage = ShelterImageFixture.shelterImage(givenShelter);
+            givenShelter.setShelterImage(givenShelterImage);
+
+            given(shelterRepository.findById(anyLong())).willReturn(
+                Optional.ofNullable(givenShelter));
+            FindShelterMyPageResponse expectedFindShelterMyPageResponse = FindShelterMyPageResponse.from(
+                givenShelter);
+
+            //when
+            FindShelterMyPageResponse foundShelterMyPageResponse = shelterService.findShelterMyPage(
+                anyLong());
+
+            //then
+            assertThat(foundShelterMyPageResponse).usingRecursiveComparison()
+                .ignoringFields("shelterId")
+                .isEqualTo(expectedFindShelterMyPageResponse);
+        }
+
+        @Test
+        @DisplayName("예외(ShelterNotFoundException): 존재하지 않은 보호소")
+        void throwExceptionWhenShelterNotFound() {
+            //given
+            Long shelterId = 1L;
+
+            given(shelterRepository.findById(any())).willReturn(Optional.empty());
+
+            // when
+            Exception exception = catchException(
+                () -> shelterService.findShelterMyPage(shelterId));
 
             // then
             assertThat(exception).isInstanceOf(ShelterNotFoundException.class);

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
@@ -2,7 +2,6 @@ package com.clova.anifriends.domain.shelter.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
@@ -68,7 +67,7 @@ class ShelterServiceTest {
             //given
             Long shelterId = 1L;
 
-            given(shelterRepository.findById(any())).willReturn(Optional.empty());
+            given(shelterRepository.findById(anyLong())).willReturn(Optional.empty());
 
             // when
             Exception exception = catchException(
@@ -112,7 +111,7 @@ class ShelterServiceTest {
             //given
             Long shelterId = 1L;
 
-            given(shelterRepository.findById(any())).willReturn(Optional.empty());
+            given(shelterRepository.findById(anyLong())).willReturn(Optional.empty());
 
             // when
             Exception exception = catchException(


### PR DESCRIPTION
### ⛏ 작업 사항
- 보호소 마이페이지 서비스, 컨트롤러 로직 구현
- 보호소 마이페이지 서비스, 컨트롤러 테스트 코드 작성
- BaseControllerTest에 shelterAccessToken을 추가
- 보호소 controller에 shelterAccessToken 적용

### 📝 작업 요약
- 보호소 마이페이지 서비스, 컨트롤러 로직 구현

### 💡 관련 이슈
- close #50 
