### PR TITLE
fix: 봉사자 마이페이지에서 imageUrl은 optional이다.

### DIFF
--- a/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
@@ -98,7 +98,7 @@ class VolunteerControllerTest extends BaseControllerTest {
                     fieldWithPath("phoneNumber").type(STRING).description("전화번호"),
                     fieldWithPath("temperature").type(NUMBER).description("온도"),
                     fieldWithPath("volunteerCount").type(NUMBER).description("봉사 횟수"),
-                    fieldWithPath("imageUrl").type(STRING).description("프로필 이미지 URL")
+                    fieldWithPath("imageUrl").type(STRING).description("프로필 이미지 URL").optional()
                 )
             ));
     }


### PR DESCRIPTION
### ⛏ 작업 사항
봉사자 마이페이지에서 imageUrl은 optional이다.

### 📝 작업 요약
마이페이지 조회 controller test에서 imageUrl optional로 한다.

### 💡 관련 이슈
- close #60 
