### PR TITLE
feat: 보호소에서 모집글을 조회 및 검색한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/common/dto/PageInfo.java
+++ b/src/main/java/com/clova/anifriends/domain/common/dto/PageInfo.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.domain.common.dto;
+
+public record PageInfo(
+    int totalElements,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/common/dto/PageInfo.java
+++ b/src/main/java/com/clova/anifriends/domain/common/dto/PageInfo.java
@@ -1,8 +1,16 @@
 package com.clova.anifriends.domain.common.dto;
 
+import org.springframework.data.domain.Page;
+
 public record PageInfo(
-    int totalElements,
+    long totalElements,
     boolean hasNext
 ) {
 
+    public static PageInfo from(Page page) {
+        return new PageInfo(
+            page.getTotalElements(),
+            page.hasNext()
+        );
+    }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/Recruitment.java
@@ -131,4 +131,8 @@ public class Recruitment extends BaseTimeEntity {
     public int getApplicantCount() {
         return applications.size();
     }
+
+    public RecruitmentInfo getInfo() {
+        return info;
+    }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -11,8 +11,10 @@ import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,7 +53,8 @@ public class RecruitmentController {
     @GetMapping("/shelters/recruitments")
     public ResponseEntity<FindRecruitmentsByShelterResponse> findRecruitmentsByShelter(
         @LoginUser Long shelterId,
-        FindRecruitmentsByShelterRequest findRecruitmentsByShelterRequest
+        @ModelAttribute @Valid FindRecruitmentsByShelterRequest findRecruitmentsByShelterRequest,
+        Pageable pageable
     ) {
         return ResponseEntity.ok(recruitmentService.findRecruitmentsByShelter(
             shelterId,
@@ -60,8 +63,7 @@ public class RecruitmentController {
             findRecruitmentsByShelterRequest.endDate(),
             findRecruitmentsByShelterRequest.content(),
             findRecruitmentsByShelterRequest.title(),
-            findRecruitmentsByShelterRequest.pageSize(),
-            findRecruitmentsByShelterRequest.pageNumber()
+            pageable
         ));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -1,7 +1,9 @@
 package com.clova.anifriends.domain.recruitment.controller;
 
 import com.clova.anifriends.domain.auth.resolver.LoginUser;
+import com.clova.anifriends.domain.recruitment.dto.request.FindRecruitmentsByShelterRequest;
 import com.clova.anifriends.domain.recruitment.dto.request.RegisterRecruitmentRequest;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByShelterResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByVolunteerResponse;
@@ -44,5 +46,22 @@ public class RecruitmentController {
     public ResponseEntity<FindRecruitmentByVolunteerResponse> findRecruitmentByIdByVolunteer(
         @PathVariable Long recruitmentId) {
         return ResponseEntity.ok(recruitmentService.findRecruitmentByIdByVolunteer(recruitmentId));
+    }
+
+    @GetMapping("/shelters/recruitments")
+    public ResponseEntity<FindRecruitmentsByShelterResponse> findRecruitmentsByShelter(
+        @LoginUser Long shelterId,
+        FindRecruitmentsByShelterRequest findRecruitmentsByShelterRequest
+    ) {
+        return ResponseEntity.ok(recruitmentService.findRecruitmentsByShelter(
+            shelterId,
+            findRecruitmentsByShelterRequest.keyword(),
+            findRecruitmentsByShelterRequest.startDate(),
+            findRecruitmentsByShelterRequest.endDate(),
+            findRecruitmentsByShelterRequest.content(),
+            findRecruitmentsByShelterRequest.title(),
+            findRecruitmentsByShelterRequest.pageSize(),
+            findRecruitmentsByShelterRequest.pageNumber()
+        ));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
@@ -1,0 +1,27 @@
+package com.clova.anifriends.domain.recruitment.dto.request;
+
+import java.time.LocalDate;
+
+public record FindRecruitmentsByShelterRequest(
+    String keyword,
+    LocalDate startDate,
+    LocalDate endDate,
+    Boolean content,
+    Boolean title,
+    Integer pageSize,
+    Integer pageNumber
+) {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+
+    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title, Integer pageSize, Integer pageNumber) {
+        this.keyword = keyword;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.content = content == null || content;
+        this.title = title == null || title;
+        this.pageSize = pageSize == null ? DEFAULT_PAGE_SIZE : pageSize;
+        this.pageNumber = pageNumber == null ? DEFAULT_PAGE_NUMBER : pageNumber;
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
@@ -7,21 +7,14 @@ public record FindRecruitmentsByShelterRequest(
     LocalDate startDate,
     LocalDate endDate,
     Boolean content,
-    Boolean title,
-    Integer pageSize,
-    Integer pageNumber
+    Boolean title
 ) {
 
-    private static final int DEFAULT_PAGE_SIZE = 10;
-    private static final int DEFAULT_PAGE_NUMBER = 0;
-
-    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title, Integer pageSize, Integer pageNumber) {
+    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title) {
         this.keyword = keyword;
         this.startDate = startDate;
         this.endDate = endDate;
         this.content = content == null || content;
         this.title = title == null || title;
-        this.pageSize = pageSize == null ? DEFAULT_PAGE_SIZE : pageSize;
-        this.pageNumber = pageNumber == null ? DEFAULT_PAGE_NUMBER : pageNumber;
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
@@ -34,7 +34,7 @@ public record FindRecruitmentsByShelterResponse(
         }
     }
 
-    public static FindRecruitmentsByShelterResponse from(List<Recruitment> recruitments, PageInfo pageInfo){
+    public static FindRecruitmentsByShelterResponse of(List<Recruitment> recruitments, PageInfo pageInfo){
         return new FindRecruitmentsByShelterResponse(
             pageInfo,
             recruitments.stream()
@@ -42,5 +42,4 @@ public record FindRecruitmentsByShelterResponse(
                 .toList()
         );
     }
-
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
@@ -1,0 +1,46 @@
+package com.clova.anifriends.domain.recruitment.dto.response;
+
+import com.clova.anifriends.domain.common.dto.PageInfo;
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FindRecruitmentsByShelterResponse(
+    PageInfo pageInfo,
+    List<RecruitmentResponse> recruitments
+
+) {
+    private record RecruitmentResponse(
+       long recruitmentId,
+        String title,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        LocalDateTime deadline,
+        boolean isClosed,
+        int applicantCount,
+        int capacity
+    ) {
+        private static RecruitmentResponse from(Recruitment recruitment){
+            return new RecruitmentResponse(
+                recruitment.getRecruitmentId(),
+                recruitment.getTitle(),
+                recruitment.getStartTime(),
+                recruitment.getEndTime(),
+                recruitment.getDeadline(),
+                recruitment.isClosed(),
+                recruitment.getApplicantCount(),
+                recruitment.getCapacity()
+            );
+        }
+    }
+
+    public static FindRecruitmentsByShelterResponse from(List<Recruitment> recruitments, PageInfo pageInfo){
+        return new FindRecruitmentsByShelterResponse(
+            pageInfo,
+            recruitments.stream()
+                .map(RecruitmentResponse::from)
+                .toList()
+        );
+    }
+
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -3,6 +3,6 @@ package com.clova.anifriends.domain.recruitment.repository;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentRepositoryCustom {
 
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -2,12 +2,12 @@ package com.clova.anifriends.domain.recruitment.repository;
 
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import java.time.LocalDate;
-import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RecruitmentRepositoryCustom {
 
-    List<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId, String keyword,
+    Page<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId, String keyword,
         LocalDate startDate, LocalDate endDate, boolean content, boolean title, Pageable pageable);
 
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface RecruitmentRepositoryCustom {
 
     Page<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId, String keyword,
-        LocalDate startDate, LocalDate endDate, boolean content, boolean title, Pageable pageable);
+        LocalDate startDate, LocalDate endDate, Boolean content, Boolean title, Pageable pageable);
 
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.clova.anifriends.domain.recruitment.repository;
+
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface RecruitmentRepositoryCustom {
+
+    List<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId, String keyword,
+        LocalDate startDate, LocalDate endDate, boolean content, boolean title, Pageable pageable);
+
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.clova.anifriends.domain.recruitment.repository;
+
+import static com.clova.anifriends.domain.recruitment.QRecruitment.recruitment;
+
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId,
+        String keyword, LocalDate startDate, LocalDate endDate, boolean content, boolean title,
+        Pageable pageable) {
+
+        Predicate predicate = recruitment.shelter.shelterId.eq(shelterId)
+            .and(getDateCondition(startDate, endDate))
+            .and(getKeywordCondition(keyword, content, title));
+
+        return queryFactory.selectFrom(recruitment)
+            .where(predicate)
+            .orderBy(recruitment.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    Predicate getDateCondition(LocalDate startDate, LocalDate endDate) {
+        BooleanExpression predicate = recruitment.isNotNull();
+        if (startDate != null) {
+            predicate = predicate.and(recruitment.info.startTime.goe(startDate.atStartOfDay()));
+        }
+        if (endDate != null) {
+            predicate = predicate.and(recruitment.info.startTime.loe(endDate.atStartOfDay()));
+        }
+        return predicate;
+    }
+
+    Predicate getKeywordCondition(String keyword, boolean content, boolean title) {
+        BooleanExpression predicate = recruitment.isNotNull();
+        if (keyword == null || keyword.isBlank()) {
+            return predicate;
+        }
+        if (content) {
+            predicate = predicate.or(recruitment.content.content.contains(keyword));
+        }
+        if (title) {
+            predicate = predicate.or(recruitment.title.title.contains(keyword));
+        }
+        return predicate;
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -22,7 +22,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
 
     @Override
     public Page<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId,
-        String keyword, LocalDate startDate, LocalDate endDate, boolean content, boolean title,
+        String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title,
         Pageable pageable) {
 
         Predicate predicate = recruitment.shelter.shelterId.eq(shelterId)
@@ -49,7 +49,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
         return predicate;
     }
 
-    Predicate getKeywordCondition(String keyword, boolean content, boolean title) {
+    Predicate getKeywordCondition(String keyword, Boolean content, Boolean title) {
         BooleanExpression predicate = recruitment.isNotNull();
         if (keyword == null || keyword.isBlank()) {
             return predicate;

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -9,6 +9,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -19,7 +21,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId,
+    public Page<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId,
         String keyword, LocalDate startDate, LocalDate endDate, boolean content, boolean title,
         Pageable pageable) {
 
@@ -27,12 +29,13 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
             .and(getDateCondition(startDate, endDate))
             .and(getKeywordCondition(keyword, content, title));
 
-        return queryFactory.selectFrom(recruitment)
+        List<Recruitment> recruitments =  queryFactory.selectFrom(recruitment)
             .where(predicate)
             .orderBy(recruitment.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
+        return new PageImpl<>(recruitments);
     }
 
     Predicate getDateCondition(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -16,7 +16,7 @@ import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,8 +45,7 @@ public class RecruitmentService {
         LocalDate endDate,
         Boolean content,
         Boolean title,
-        int page,
-        int size
+        Pageable pageable
     ) {
         Page<Recruitment> pagination = recruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
             shelterId,
@@ -55,7 +54,7 @@ public class RecruitmentService {
             endDate,
             content,
             title,
-            PageRequest.of(page, size)
+            pageable
         );
 
         return FindRecruitmentsByShelterResponse.of(pagination.getContent(), PageInfo.from(pagination));

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -43,8 +43,8 @@ public class RecruitmentService {
         String keyword,
         LocalDate startDate,
         LocalDate endDate,
-        boolean content,
-        boolean title,
+        Boolean content,
+        Boolean title,
         int page,
         int size
     ) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -1,17 +1,22 @@
 package com.clova.anifriends.domain.recruitment.service;
 
+import com.clova.anifriends.domain.common.dto.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.request.RegisterRecruitmentRequest;
-import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByShelterResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByVolunteerResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.clova.anifriends.domain.recruitment.mapper.RecruitmentMapper;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +35,30 @@ public class RecruitmentService {
         Recruitment recruitment = RecruitmentMapper.toRecruitment(shelter, request);
         recruitmentRepository.save(recruitment);
         return RegisterRecruitmentResponse.from(recruitment);
+    }
+
+    @Transactional(readOnly = true)
+    public FindRecruitmentsByShelterResponse findRecruitmentsByShelter(
+        Long shelterId,
+        String keyword,
+        LocalDate startDate,
+        LocalDate endDate,
+        boolean content,
+        boolean title,
+        int page,
+        int size
+    ) {
+        Page<Recruitment> pagination = recruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
+            shelterId,
+            keyword,
+            startDate,
+            endDate,
+            content,
+            title,
+            PageRequest.of(page, size)
+        );
+
+        return FindRecruitmentsByShelterResponse.of(pagination.getContent(), PageInfo.from(pagination));
     }
 
     private Shelter getShelterById(Long shelterId) {

--- a/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
@@ -4,9 +4,10 @@ import com.clova.anifriends.domain.review.Review;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("select r from Review r where r.reviewId = :reviewId and r.volunteer.volunteerId = :userId")
-    Optional<Review> findByReviewIdAndVolunteerId(Long reviewId, Long userId);
+    Optional<Review> findByReviewIdAndVolunteerId(@Param("reviewId") Long reviewId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/clova/anifriends/global/config/QueryDslConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.clova.anifriends.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Autowired
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -204,9 +204,11 @@ class RecruitmentControllerTest extends BaseControllerTest {
         Recruitment recruitment = recruitment(shelter);
         ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
         Page<Recruitment> pageResult = new PageImpl<>(List.of(recruitment));
-        FindRecruitmentsByShelterResponse response = RecruitmentDtoFixture.findRecruitmentsByShelterResponse(pageResult);
+        FindRecruitmentsByShelterResponse response = RecruitmentDtoFixture.findRecruitmentsByShelterResponse(
+            pageResult);
 
-        when(recruitmentService.findRecruitmentsByShelter(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
+        when(recruitmentService.findRecruitmentsByShelter(anyLong(), any(), any(), any(),
+            anyBoolean(), anyBoolean(), any()))
             .thenReturn(response);
 
         // when
@@ -222,10 +224,14 @@ class RecruitmentControllerTest extends BaseControllerTest {
                 requestHeaders(headerWithName(AUTHORIZATION).description("액세스 토큰")),
                 queryParameters(
                     parameterWithName("keyword").description("검색어").optional(),
-                    parameterWithName("startDate").description("검색 시작 날짜").optional(),
-                    parameterWithName("endDate").description("검색 종료 날짜").optional(),
-                    parameterWithName("content").description("내용 검색 여부").optional(),
-                    parameterWithName("title").description("제목 검색 여부").optional(),
+                    parameterWithName("startDate").description("검색 시작 날짜").optional()
+                        .attributes(DocumentationFormatGenerator.getDateConstraint()),
+                    parameterWithName("endDate").description("검색 종료 날짜").optional()
+                        .attributes(DocumentationFormatGenerator.getDateConstraint()),
+                    parameterWithName("content").description("내용 검색 여부").optional()
+                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 null")),
+                    parameterWithName("title").description("제목 검색 여부").optional()
+                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 null")),
                     parameterWithName("pageSize").description("페이지 크기").optional(),
                     parameterWithName("pageNumber").description("페이지 번호").optional()
                 ),
@@ -239,7 +245,8 @@ class RecruitmentControllerTest extends BaseControllerTest {
                     fieldWithPath("recruitments[].endTime").type(STRING).description("봉사 끝난 시간"),
                     fieldWithPath("recruitments[].deadline").type(STRING).description("모집 마감 시간"),
                     fieldWithPath("recruitments[].isClosed").type(BOOLEAN).description("모집 마감 여부"),
-                    fieldWithPath("recruitments[].applicantCount").type(NUMBER).description("현재 지원자 수"),
+                    fieldWithPath("recruitments[].applicantCount").type(NUMBER)
+                        .description("현재 지원자 수"),
                     fieldWithPath("recruitments[].capacity").type(NUMBER).description("모집 정원")
                 )
             ));

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -5,14 +5,14 @@ import static com.clova.anifriends.domain.recruitment.support.fixture.Recruitmen
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture.recruitment;
 import static com.clova.anifriends.domain.shelter.support.ShelterFixture.shelter;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
@@ -24,6 +24,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,18 +33,23 @@ import com.clova.anifriends.docs.format.DocumentationFormatGenerator;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.request.RegisterRecruitmentRequest;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByShelterResponse;
-import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByVolunteerResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
+import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentDtoFixture;
 import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.ShelterImage;
+import com.clova.anifriends.domain.shelter.support.ShelterImageFixture;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import com.clova.anifriends.domain.shelter.ShelterImage;
-import com.clova.anifriends.domain.shelter.support.ShelterImageFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
 class RecruitmentControllerTest extends BaseControllerTest {
@@ -187,6 +193,55 @@ class RecruitmentControllerTest extends BaseControllerTest {
                     fieldWithPath("shelterInfo.imageUrl").type(STRING).description("보호소 이미지 url")
                         .optional(),
                     fieldWithPath("shelterInfo.email").type(STRING).description("보호소 이메일")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("findRecruitmentsByShelter 실행 시")
+    void findRecruitmentsByShelter() throws Exception {
+        // given
+        Shelter shelter = shelter();
+        Recruitment recruitment = recruitment(shelter);
+        ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
+        Page<Recruitment> pageResult = new PageImpl<>(List.of(recruitment));
+        FindRecruitmentsByShelterResponse response = RecruitmentDtoFixture.findRecruitmentsByShelterResponse(pageResult);
+
+        when(recruitmentService.findRecruitmentsByShelter(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), anyInt(), anyInt()))
+            .thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            get("/api/shelters/recruitments")
+                .header(AUTHORIZATION, shelterAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestHeaders(headerWithName(AUTHORIZATION).description("액세스 토큰")),
+                queryParameters(
+                    parameterWithName("keyword").description("검색어").optional(),
+                    parameterWithName("startDate").description("검색 시작 날짜").optional(),
+                    parameterWithName("endDate").description("검색 종료 날짜").optional(),
+                    parameterWithName("content").description("내용 검색 여부").optional(),
+                    parameterWithName("title").description("제목 검색 여부").optional(),
+                    parameterWithName("pageSize").description("페이지 크기").optional(),
+                    parameterWithName("pageNumber").description("페이지 번호").optional()
+                ),
+                responseFields(
+                    fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 게시글 수"),
+                    fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부"),
+                    fieldWithPath("recruitments[]").type(ARRAY).description("모집 게시글 리스트"),
+                    fieldWithPath("recruitments[].recruitmentId").type(NUMBER).description("모집 ID"),
+                    fieldWithPath("recruitments[].title").type(STRING).description("모집 제목"),
+                    fieldWithPath("recruitments[].startTime").type(STRING).description("봉사 시작 시간"),
+                    fieldWithPath("recruitments[].endTime").type(STRING).description("봉사 끝난 시간"),
+                    fieldWithPath("recruitments[].deadline").type(STRING).description("모집 마감 시간"),
+                    fieldWithPath("recruitments[].isClosed").type(BOOLEAN).description("모집 마감 여부"),
+                    fieldWithPath("recruitments[].applicantCount").type(NUMBER).description("현재 지원자 수"),
+                    fieldWithPath("recruitments[].capacity").type(NUMBER).description("모집 정원")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -6,7 +6,6 @@ import static com.clova.anifriends.domain.recruitment.support.fixture.Recruitmen
 import static com.clova.anifriends.domain.shelter.support.ShelterFixture.shelter;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -207,7 +206,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
         Page<Recruitment> pageResult = new PageImpl<>(List.of(recruitment));
         FindRecruitmentsByShelterResponse response = RecruitmentDtoFixture.findRecruitmentsByShelterResponse(pageResult);
 
-        when(recruitmentService.findRecruitmentsByShelter(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), anyInt(), anyInt()))
+        when(recruitmentService.findRecruitmentsByShelter(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
             .thenReturn(response);
 
         // when

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImplTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImplTest.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.recruitment.repository;
 
 import static com.clova.anifriends.domain.shelter.support.ShelterFixture.shelter;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.clova.anifriends.base.BaseRepositoryTest;
 import com.clova.anifriends.domain.recruitment.Recruitment;
@@ -11,11 +12,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class RecruitmentRepositoryImplTest extends BaseRepositoryTest {
 
@@ -28,71 +29,141 @@ class RecruitmentRepositoryImplTest extends BaseRepositoryTest {
     @Autowired
     private ShelterRepository shelterRepository;
 
-    @Test
-    @DisplayName("findRecruitmentsByShelterOrderByCreatedAt 실행 시")
-    void findRecruitmentsByShelterOrderByCreatedAt() {
-        // given
-        Shelter shelter = shelter();
-        ReflectionTestUtils.setField(shelter, "shelterId", 1L);
+    @Nested
+    @DisplayName("findRecruitmentsByShelterOrderByCreatedAt 메서드 실행 시")
+    class FindRecruitmentsByShelterOrderByCreatedAtTest {
 
-        shelterRepository.save(shelter);
+        @Test
+        @DisplayName("성공: 모든 인자가 주어졌을 때")
+        void findRecruitmentsWhenArgsAreNotNull() {
+            // given
+            Shelter shelter = shelter();
+            setField(shelter, "shelterId", 1L);
 
-        Recruitment recruitment1 = new Recruitment(
-          shelter,
-            "a",
-            10,
-            "d",
-            LocalDateTime.now().plusMonths(2),
-            LocalDateTime.now().plusMonths(2).plusHours(3),
-            LocalDateTime.now().plusDays(1),
-            List.of()
-        );
+            shelterRepository.save(shelter);
 
-        Recruitment recruitment2 = new Recruitment(
-          shelter,
-            "ab",
-            10,
-            "de",
-            LocalDateTime.now().plusMonths(3),
-            LocalDateTime.now().plusMonths(3).plusHours(3),
-            LocalDateTime.now().plusMonths(1),
-            List.of()
-        );
+            Recruitment recruitment1 = new Recruitment(
+                shelter,
+                "a",
+                10,
+                "d",
+                LocalDateTime.now().plusMonths(2),
+                LocalDateTime.now().plusMonths(2).plusHours(3),
+                LocalDateTime.now().plusDays(1),
+                List.of()
+            );
 
-        ReflectionTestUtils.setField(recruitment2.getInfo(), "isClosed", true);
+            Recruitment recruitment2 = new Recruitment(
+                shelter,
+                "ab",
+                10,
+                "de",
+                LocalDateTime.now().plusMonths(3),
+                LocalDateTime.now().plusMonths(3).plusHours(3),
+                LocalDateTime.now().plusMonths(1),
+                List.of()
+            );
 
-        Recruitment recruitment3 = new Recruitment(
-          shelter,
-            "abc",
-            10,
-            "def",
-            LocalDateTime.now().plusMonths(4),
-            LocalDateTime.now().plusMonths(4).plusHours(3),
-            LocalDateTime.now().plusMonths(2),
-            List.of()
-        );
+            setField(recruitment2.getInfo(), "isClosed", true);
 
-        recruitmentRepository.saveAll(List.of(recruitment1, recruitment2, recruitment3));
+            Recruitment recruitment3 = new Recruitment(
+                shelter,
+                "abc",
+                10,
+                "def",
+                LocalDateTime.now().plusMonths(4),
+                LocalDateTime.now().plusMonths(4).plusHours(3),
+                LocalDateTime.now().plusMonths(2),
+                List.of()
+            );
 
-        String keyword = "ab";
-        LocalDate startDate = LocalDate.now().plusMonths(3);
-        LocalDate endDate = LocalDate.now().plusMonths(5);
-        boolean content = true;
-        boolean title = true;
-        PageRequest pageable = PageRequest.of(0, 10);
+            recruitmentRepository.saveAll(List.of(recruitment1, recruitment2, recruitment3));
 
-        // when
-        Page<Recruitment> recruitments = customRecruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
-            shelter.getShelterId(),
-            keyword,
-            startDate,
-            endDate,
-            content,
-            title,
-            pageable
-        );
+            String keyword = "ab";
+            LocalDate startDate = LocalDate.now().plusMonths(3);
+            LocalDate endDate = LocalDate.now().plusMonths(5);
+            boolean content = true;
+            boolean title = true;
+            PageRequest pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(recruitments).contains(recruitment2, recruitment3);
+            // when
+            Page<Recruitment> recruitments = customRecruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
+                shelter.getShelterId(),
+                keyword,
+                startDate,
+                endDate,
+                content,
+                title,
+                pageable
+            );
+
+            // then
+            assertThat(recruitments).contains(recruitment2, recruitment3);
+        }
+
+        @Test
+        @DisplayName("성공: 모든 인자가 null")
+        void findRecruitmentsWhenArgsAreNull() {
+            // given
+            Shelter shelter = shelter();
+            setField(shelter, "shelterId", 1L);
+
+            shelterRepository.save(shelter);
+
+            Recruitment recruitment1 = new Recruitment(
+                shelter,
+                "a",
+                10,
+                "d",
+                LocalDateTime.now().plusMonths(2),
+                LocalDateTime.now().plusMonths(2).plusHours(3),
+                LocalDateTime.now().plusDays(1),
+                List.of()
+            );
+
+            Recruitment recruitment2 = new Recruitment(
+                shelter,
+                "ab",
+                10,
+                "de",
+                LocalDateTime.now().plusMonths(3),
+                LocalDateTime.now().plusMonths(3).plusHours(3),
+                LocalDateTime.now().plusMonths(1),
+                List.of()
+            );
+
+            setField(recruitment2.getInfo(), "isClosed", true);
+
+            Recruitment recruitment3 = new Recruitment(
+                shelter,
+                "abc",
+                10,
+                "def",
+                LocalDateTime.now().plusMonths(4),
+                LocalDateTime.now().plusMonths(4).plusHours(3),
+                LocalDateTime.now().plusMonths(2),
+                List.of()
+            );
+
+            recruitmentRepository.saveAll(List.of(recruitment1, recruitment2, recruitment3));
+
+            PageRequest pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Recruitment> recruitments = customRecruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
+                shelter.getShelterId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                pageable
+            );
+
+            // then
+            assertThat(recruitments).contains(recruitment1, recruitment2, recruitment3);
+        }
     }
+
+
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImplTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImplTest.java
@@ -1,0 +1,97 @@
+package com.clova.anifriends.domain.recruitment.repository;
+
+import static com.clova.anifriends.domain.shelter.support.ShelterFixture.shelter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.clova.anifriends.base.BaseRepositoryTest;
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecruitmentRepositoryImplTest extends BaseRepositoryTest {
+
+    @Autowired
+    private RecruitmentRepositoryImpl customRecruitmentRepository;
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private ShelterRepository shelterRepository;
+
+    @Test
+    @DisplayName("findRecruitmentsByShelterOrderByCreatedAt 실행 시")
+    void findRecruitmentsByShelterOrderByCreatedAt() {
+        // given
+        Shelter shelter = shelter();
+        ReflectionTestUtils.setField(shelter, "shelterId", 1L);
+
+        shelterRepository.save(shelter);
+
+        Recruitment recruitment1 = new Recruitment(
+          shelter,
+            "a",
+            10,
+            "d",
+            LocalDateTime.now().plusMonths(2),
+            LocalDateTime.now().plusMonths(2).plusHours(3),
+            LocalDateTime.now().plusDays(1),
+            List.of()
+        );
+
+        Recruitment recruitment2 = new Recruitment(
+          shelter,
+            "ab",
+            10,
+            "de",
+            LocalDateTime.now().plusMonths(3),
+            LocalDateTime.now().plusMonths(3).plusHours(3),
+            LocalDateTime.now().plusMonths(1),
+            List.of()
+        );
+
+        ReflectionTestUtils.setField(recruitment2.getInfo(), "isClosed", true);
+
+        Recruitment recruitment3 = new Recruitment(
+          shelter,
+            "abc",
+            10,
+            "def",
+            LocalDateTime.now().plusMonths(4),
+            LocalDateTime.now().plusMonths(4).plusHours(3),
+            LocalDateTime.now().plusMonths(2),
+            List.of()
+        );
+
+        recruitmentRepository.saveAll(List.of(recruitment1, recruitment2, recruitment3));
+
+        String keyword = "ab";
+        LocalDate startDate = LocalDate.now().plusMonths(3);
+        LocalDate endDate = LocalDate.now().plusMonths(5);
+        boolean content = true;
+        boolean title = true;
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // when
+        List<Recruitment> recruitments = customRecruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
+            shelter.getShelterId(),
+            keyword,
+            startDate,
+            endDate,
+            content,
+            title,
+            pageable
+        );
+
+        // then
+        assertThat(recruitments).contains(recruitment2, recruitment3);
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImplTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImplTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -81,7 +82,7 @@ class RecruitmentRepositoryImplTest extends BaseRepositoryTest {
         PageRequest pageable = PageRequest.of(0, 10);
 
         // when
-        List<Recruitment> recruitments = customRecruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
+        Page<Recruitment> recruitments = customRecruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
             shelter.getShelterId(),
             keyword,
             startDate,

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -196,7 +195,7 @@ class RecruitmentServiceTest {
 
             // when
             FindRecruitmentsByShelterResponse result = recruitmentService.findRecruitmentsByShelter(
-                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), anyInt(), 5);
+                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any());
 
             // then
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -2,12 +2,15 @@ package com.clova.anifriends.domain.recruitment.service;
 
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentDtoFixture.findRecruitmentByVolunteerResponse;
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentDtoFixture.findRecruitmentResponse;
+import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentDtoFixture.findRecruitmentsByShelterResponse;
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture.recruitment;
 import static com.clova.anifriends.domain.shelter.support.ShelterFixture.shelter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -18,14 +21,15 @@ import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.request.RegisterRecruitmentRequest;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByShelterResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByVolunteerResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterResponse;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.ShelterImage;
-import com.clova.anifriends.domain.shelter.support.ShelterImageFixture;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import com.clova.anifriends.domain.shelter.support.ShelterImageFixture;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +40,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
 @ExtendWith(MockitoExtension.class)
 class RecruitmentServiceTest {
@@ -137,7 +143,7 @@ class RecruitmentServiceTest {
 
         @Test
         @DisplayName("성공")
-        void success() {
+        void findRecruitmentByIdByVolunteer() {
             // given
             Shelter shelter = shelter();
             ShelterImage shelterImage = ShelterImageFixture.shelterImage(shelter);
@@ -167,6 +173,33 @@ class RecruitmentServiceTest {
 
             // then
             assertThat(exception).isInstanceOf(RecruitmentNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("findRecruitmentsByShelter 메서드 실행 시")
+    class FindRecruitmentsByShelterTest {
+
+        @Test
+        @DisplayName("성공")
+        void findRecruitmentsByShelter() {
+            // given
+            Shelter shelter = shelter();
+            Recruitment recruitment = recruitment(shelter);
+            setField(recruitment, "recruitmentId", 4L);
+            Page<Recruitment> pageResult = new PageImpl<>(List.of(recruitment));
+            FindRecruitmentsByShelterResponse expected = findRecruitmentsByShelterResponse(pageResult);
+
+            when(recruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
+                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
+                .thenReturn(pageResult);
+
+            // when
+            FindRecruitmentsByShelterResponse result = recruitmentService.findRecruitmentsByShelter(
+                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), anyInt(), 5);
+
+            // then
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentDtoFixture.java
@@ -1,8 +1,11 @@
 package com.clova.anifriends.domain.recruitment.support.fixture;
 
+import com.clova.anifriends.domain.common.dto.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByShelterResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentByVolunteerResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterResponse;
+import org.springframework.data.domain.Page;
 
 public class RecruitmentDtoFixture {
 
@@ -14,5 +17,10 @@ public class RecruitmentDtoFixture {
     public static FindRecruitmentByVolunteerResponse findRecruitmentByVolunteerResponse(
         Recruitment recruitment) {
         return FindRecruitmentByVolunteerResponse.from(recruitment);
+    }
+
+    public static FindRecruitmentsByShelterResponse findRecruitmentsByShelterResponse(
+        Page<Recruitment> pageResult) {
+        return FindRecruitmentsByShelterResponse.of(pageResult.getContent(), PageInfo.from(pageResult));
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 보호소의 봉사 모집글 조회 및 검색 api

### 📝 작업 요약
- 보호소의 봉사 모집글 조회, 검색 api 구현
- QueryDSL Config 작성
- 관련 테스트 코드 작성


### 💡 관련 이슈
- close #65 
