### PR TITLE
fix: 보호소의 모집글 상세조회에서 보호소 Id 와 모집글 Id 로 조회하도록 변경

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -44,8 +44,10 @@ public class RecruitmentController {
 
     @GetMapping("/shelters/recruitments/{recruitmentId}")
     public ResponseEntity<FindRecruitmentByShelterResponse> findRecruitmentByIdByShelter(
+        @LoginUser Long shelterId,
         @PathVariable Long recruitmentId) {
-        return ResponseEntity.ok(recruitmentService.findRecruitmentByIdByShelter(recruitmentId));
+        return ResponseEntity.ok(recruitmentService
+            .findRecruitmentByShelterIdAndRecruitmentIdByShelter(shelterId, recruitmentId));
     }
 
     @GetMapping("/volunteers/recruitments/{recruitmentId}")

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -47,7 +47,7 @@ public class RecruitmentController {
         @LoginUser Long shelterId,
         @PathVariable Long recruitmentId) {
         return ResponseEntity.ok(recruitmentService
-            .findRecruitmentByShelterIdAndRecruitmentIdByShelter(shelterId, recruitmentId));
+            .findRecruitByShelter(shelterId, recruitmentId));
     }
 
     @GetMapping("/volunteers/recruitments/{recruitmentId}")

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.recruitment.repository;
 
 import com.clova.anifriends.domain.recruitment.Recruitment;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,10 @@ public interface RecruitmentRepository
     Page<Recruitment> findCompletedRecruitments(
         @Param("volunteerId") Long volunteerId,
         Pageable pageable);
+
+    @Query("select r from Recruitment r "
+        + "where r.shelter.shelterId = :shelterId "
+        + "and r.recruitmentId = :recruitmentId")
+    Optional<Recruitment> findByShelterIdAndRecruitmentId(
+        @Param("shelterId") long shelterId, @Param("recruitmentId") long recruitmentId);
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -69,9 +69,9 @@ public class RecruitmentService {
             .orElseThrow(() -> new ShelterNotFoundException("존재하지 않는 보호소입니다."));
     }
 
-    public FindRecruitmentByShelterResponse findRecruitmentByShelterIdAndRecruitmentIdByShelter(
+    public FindRecruitmentByShelterResponse findRecruitByShelter(
         long shelterId, long recruitmentId) {
-        Recruitment recruitment = getRecruitmentByShelterIdAndRecruitmentId(shelterId,
+        Recruitment recruitment = getRecruitmentByShelter(shelterId,
             recruitmentId);
         return FindRecruitmentByShelterResponse.from(recruitment);
     }
@@ -90,7 +90,7 @@ public class RecruitmentService {
         return FindShelterSimpleResponse.from(foundRecruitment);
     }
 
-    private Recruitment getRecruitmentByShelterIdAndRecruitmentId(long shelterId,
+    private Recruitment getRecruitmentByShelter(long shelterId,
         long recruitmentId) {
         return recruitmentRepository.findByShelterIdAndRecruitmentId(shelterId, recruitmentId)
             .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 모집글입니다."));

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -69,8 +69,10 @@ public class RecruitmentService {
             .orElseThrow(() -> new ShelterNotFoundException("존재하지 않는 보호소입니다."));
     }
 
-    public FindRecruitmentByShelterResponse findRecruitmentByIdByShelter(long id) {
-        Recruitment recruitment = getRecruitmentById(id);
+    public FindRecruitmentByShelterResponse findRecruitmentByShelterIdAndRecruitmentIdByShelter(
+        long shelterId, long recruitmentId) {
+        Recruitment recruitment = getRecruitmentByShelterIdAndRecruitmentId(shelterId,
+            recruitmentId);
         return FindRecruitmentByShelterResponse.from(recruitment);
     }
 
@@ -86,6 +88,12 @@ public class RecruitmentService {
         Recruitment foundRecruitment = getRecruitmentById(recruitmentId);
 
         return FindShelterSimpleResponse.from(foundRecruitment);
+    }
+
+    private Recruitment getRecruitmentByShelterIdAndRecruitmentId(long shelterId,
+        long recruitmentId) {
+        return recruitmentRepository.findByShelterIdAndRecruitmentId(shelterId, recruitmentId)
+            .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 모집글입니다."));
     }
 
     private Recruitment getRecruitmentById(long id) {

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -121,15 +121,18 @@ class RecruitmentControllerTest extends BaseControllerTest {
     void findRecruitment() throws Exception {
         // given
         Shelter shelter = shelter();
+        ReflectionTestUtils.setField(shelter, "shelterId", 1L);
         Recruitment recruitment = recruitment(shelter);
+        ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
         FindRecruitmentByShelterResponse response = findRecruitmentResponse(recruitment);
 
-        when(recruitmentService.findRecruitmentByIdByShelter(anyLong()))
+        when(recruitmentService.findRecruitmentByShelterIdAndRecruitmentIdByShelter(
+            shelter.getShelterId(), recruitment.getRecruitmentId()))
             .thenReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(
-            get("/api/shelters/recruitments/{recruitmentId}", anyLong())
+            get("/api/shelters/recruitments/{recruitmentId}", recruitment.getRecruitmentId())
                 .header(AUTHORIZATION, shelterAccessToken)
                 .contentType(MediaType.APPLICATION_JSON)
         );

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -126,7 +126,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
         ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
         FindRecruitmentByShelterResponse response = findRecruitmentResponse(recruitment);
 
-        when(recruitmentService.findRecruitmentByShelterIdAndRecruitmentIdByShelter(
+        when(recruitmentService.findRecruitByShelter(
             shelter.getShelterId(), recruitment.getRecruitmentId()))
             .thenReturn(response);
 

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -122,7 +122,7 @@ class RecruitmentServiceTest {
 
             // when
             FindRecruitmentByShelterResponse result = recruitmentService
-                .findRecruitmentByShelterIdAndRecruitmentIdByShelter(anyLong(), anyLong());
+                .findRecruitByShelter(anyLong(), anyLong());
 
             // then
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
@@ -138,7 +138,7 @@ class RecruitmentServiceTest {
 
             // when
             Exception exception = catchException(
-                () -> recruitmentService.findRecruitmentByShelterIdAndRecruitmentIdByShelter(
+                () -> recruitmentService.findRecruitByShelter(
                     anyLong(), anyLong()));
 
             // then

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -117,11 +117,12 @@ class RecruitmentServiceTest {
             Recruitment recruitment = recruitment(shelter);
             FindRecruitmentByShelterResponse expected = findRecruitmentResponse(recruitment);
 
-            when(recruitmentRepository.findById(anyLong())).thenReturn(Optional.of(recruitment));
+            when(recruitmentRepository.findByShelterIdAndRecruitmentId(anyLong(),
+                anyLong())).thenReturn(Optional.of(recruitment));
 
             // when
             FindRecruitmentByShelterResponse result = recruitmentService
-                .findRecruitmentByIdByShelter(anyLong());
+                .findRecruitmentByShelterIdAndRecruitmentIdByShelter(anyLong(), anyLong());
 
             // then
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
@@ -132,11 +133,13 @@ class RecruitmentServiceTest {
         @DisplayName("예외(RecruitmentNotFoundException): 존재하지 않는 모집글")
         void exceptionWhenRecruitmentIsNotExist() {
             // given
-            when(recruitmentRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(recruitmentRepository.findByShelterIdAndRecruitmentId(anyLong(),
+                anyLong())).thenReturn(Optional.empty());
 
             // when
             Exception exception = catchException(
-                () -> recruitmentService.findRecruitmentByIdByShelter(anyLong()));
+                () -> recruitmentService.findRecruitmentByShelterIdAndRecruitmentIdByShelter(
+                    anyLong(), anyLong()));
 
             // then
             assertThat(exception).isInstanceOf(RecruitmentNotFoundException.class);


### PR DESCRIPTION
### ⛏ 작업 사항
보호소의 모집글 상세조회에서 보호소 Id 와 모집글 Id 로 조회하도록 변경했습니다.

### 📝 작업 요약
- 보호소의 모집글 상세조회에서 보호소 Id 와 모집글 Id 로 조회하도록 변경

### 💡 관련 이슈
- close #58 
