### PR TITLE
fix: CodeDeploy permission denied를 해결한다.

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -4,6 +4,12 @@ files:
   - source: /
     destination: /home/ec2-user/app/deploy
 
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ec2-user
+    group: ec2-user
+
 hooks:
   ApplicationStart:
     - location: scripts/deploy.sh


### PR DESCRIPTION
### ⛏ 작업 사항
- CodeDeploy가 배포한 파일들에 접근 불가능한 문제를 해결하기 위해 쉘스크립트에 permission 설정을 추가하였습니다.

### 📝 작업 요약
- `deploy.sh` `permissions` 항목 추가


### 💡 관련 이슈
- close #103 
