### PR TITLE
feat: 이메일 중복 확인 로직을 구현한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
@@ -1,13 +1,18 @@
 package com.clova.anifriends.domain.shelter.controller;
 
 import com.clova.anifriends.domain.auth.resolver.LoginUser;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateShelterEmailRequest;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateShelterResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.service.ShelterService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class ShelterController {
 
     private final ShelterService shelterService;
+
+    @PostMapping("/shelters/email")
+    public ResponseEntity<CheckDuplicateShelterResponse> checkDuplicateShelterEmail(
+        @RequestBody @Valid CheckDuplicateShelterEmailRequest checkDuplicateShelterEmailRequest) {
+        CheckDuplicateShelterResponse checkDuplicateShelterResponse
+            = shelterService.checkDuplicateEmail(checkDuplicateShelterEmailRequest.email());
+        return ResponseEntity.ok(checkDuplicateShelterResponse);
+    }
 
     @GetMapping("/volunteers/shelters/{shelterId}/profile")
     public ResponseEntity<FindShelterDetailResponse> findShelterDetail(

--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateEmailResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateEmailResponse.java
@@ -1,9 +1,0 @@
-package com.clova.anifriends.domain.shelter.dto;
-
-public record CheckDuplicateEmailResponse(
-    boolean isDuplicated) {
-
-    public static CheckDuplicateEmailResponse from(boolean isDuplicated) {
-        return new CheckDuplicateEmailResponse(isDuplicated);
-    }
-}

--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateEmailResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateEmailResponse.java
@@ -1,0 +1,9 @@
+package com.clova.anifriends.domain.shelter.dto;
+
+public record CheckDuplicateEmailResponse(
+    boolean isDuplicated) {
+
+    public static CheckDuplicateEmailResponse from(boolean isDuplicated) {
+        return new CheckDuplicateEmailResponse(isDuplicated);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateShelterEmailRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateShelterEmailRequest.java
@@ -1,0 +1,9 @@
+package com.clova.anifriends.domain.shelter.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckDuplicateShelterEmailRequest(
+    @NotBlank(message = "이메일은 필수값입니다.")
+    String email) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/CheckDuplicateShelterResponse.java
@@ -1,0 +1,9 @@
+package com.clova.anifriends.domain.shelter.dto;
+
+public record CheckDuplicateShelterResponse(
+    boolean isDuplicated) {
+
+    public static CheckDuplicateShelterResponse from(boolean isDuplicated) {
+        return new CheckDuplicateShelterResponse(isDuplicated);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/shelter/exception/ShelterConflictException.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/exception/ShelterConflictException.java
@@ -1,0 +1,11 @@
+package com.clova.anifriends.domain.shelter.exception;
+
+import com.clova.anifriends.global.exception.ConflictException;
+import com.clova.anifriends.global.exception.ErrorCode;
+
+public class ShelterConflictException extends ConflictException {
+
+    public ShelterConflictException(String message) {
+        super(ErrorCode.ALREADY_EXISTS, message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/repository/ShelterRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ShelterRepository extends JpaRepository<Shelter, Long> {
 
     Optional<Shelter> findByEmail(ShelterEmail email);
+
+    boolean existsByEmail(ShelterEmail email);
 }

--- a/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
@@ -1,7 +1,7 @@
 package com.clova.anifriends.domain.shelter.service;
 
 import com.clova.anifriends.domain.shelter.Shelter;
-import com.clova.anifriends.domain.shelter.dto.CheckDuplicateEmailResponse;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateShelterResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
@@ -18,9 +18,9 @@ public class ShelterService {
     private final ShelterRepository shelterRepository;
 
     @Transactional(readOnly = true)
-    public CheckDuplicateEmailResponse checkDuplicateEmail(String email) {
+    public CheckDuplicateShelterResponse checkDuplicateEmail(String email) {
         boolean isDuplicated = shelterRepository.existsByEmail(new ShelterEmail(email));
-        return CheckDuplicateEmailResponse.from(isDuplicated);
+        return CheckDuplicateShelterResponse.from(isDuplicated);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
@@ -1,10 +1,12 @@
 package com.clova.anifriends.domain.shelter.service;
 
 import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateEmailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
+import com.clova.anifriends.domain.shelter.wrapper.ShelterEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShelterService {
 
     private final ShelterRepository shelterRepository;
+
+    @Transactional(readOnly = true)
+    public CheckDuplicateEmailResponse checkDuplicateEmail(String email) {
+        boolean isDuplicated = shelterRepository.existsByEmail(new ShelterEmail(email));
+        return CheckDuplicateEmailResponse.from(isDuplicated);
+    }
 
     @Transactional(readOnly = true)
     public FindShelterDetailResponse findShelterDetail(

--- a/src/main/java/com/clova/anifriends/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/controller/VolunteerController.java
@@ -1,7 +1,9 @@
 package com.clova.anifriends.domain.volunteer.controller;
 
 import com.clova.anifriends.domain.auth.resolver.LoginUser;
+import com.clova.anifriends.domain.volunteer.dto.request.CheckDuplicateVolunteerEmailRequest;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
+import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
 import com.clova.anifriends.domain.volunteer.service.VolunteerService;
@@ -23,6 +25,15 @@ public class VolunteerController {
 
     private final VolunteerService volunteerService;
     private static final String BASE_URI = "/api/volunteers/";
+
+    @PostMapping("/volunteers/email")
+    public ResponseEntity<CheckDuplicateVolunteerEmailResponse> checkDuplicateVolunteerEmail(
+        @RequestBody @Valid CheckDuplicateVolunteerEmailRequest checkDuplicateVolunteerEmailRequest) {
+        String targetEmail = checkDuplicateVolunteerEmailRequest.email();
+        CheckDuplicateVolunteerEmailResponse checkDuplicateVolunteerEmailResponse
+            = volunteerService.checkDuplicateVolunteerEmail(targetEmail);
+        return ResponseEntity.ok(checkDuplicateVolunteerEmailResponse);
+    }
 
     @PostMapping("/volunteers")
     public ResponseEntity<Void> registerVolunteer(

--- a/src/main/java/com/clova/anifriends/domain/volunteer/dto/request/CheckDuplicateVolunteerEmailRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/dto/request/CheckDuplicateVolunteerEmailRequest.java
@@ -1,0 +1,5 @@
+package com.clova.anifriends.domain.volunteer.dto.request;
+
+public record CheckDuplicateVolunteerEmailRequest() {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/volunteer/dto/request/CheckDuplicateVolunteerEmailRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/dto/request/CheckDuplicateVolunteerEmailRequest.java
@@ -1,5 +1,9 @@
 package com.clova.anifriends.domain.volunteer.dto.request;
 
-public record CheckDuplicateVolunteerEmailRequest() {
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckDuplicateVolunteerEmailRequest(
+    @NotBlank(message = "이메일은 필수값입니다.")
+    String email) {
 
 }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/CheckDuplicateVolunteerEmailResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/CheckDuplicateVolunteerEmailResponse.java
@@ -1,0 +1,8 @@
+package com.clova.anifriends.domain.volunteer.dto.response;
+
+public record CheckDuplicateVolunteerEmailResponse(boolean isDuplicated) {
+
+    public static CheckDuplicateVolunteerEmailResponse from(boolean isDuplicated) {
+        return new CheckDuplicateVolunteerEmailResponse(isDuplicated);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/volunteer/repository/VolunteerRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/repository/VolunteerRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface VolunteerRepository extends JpaRepository<Volunteer, Long> {
 
     Optional<Volunteer> findByEmail(VolunteerEmail email);
+
+    boolean existsByEmail(VolunteerEmail email);
 }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/service/VolunteerService.java
@@ -1,10 +1,12 @@
 package com.clova.anifriends.domain.volunteer.service;
 
 import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerNotFoundException;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
+import com.clova.anifriends.domain.volunteer.wrapper.VolunteerEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class VolunteerService {
 
     private final VolunteerRepository volunteerRepository;
+
+    @Transactional(readOnly = true)
+    public CheckDuplicateVolunteerEmailResponse checkDuplicateVolunteerEmail(String email) {
+        boolean isDuplicated = volunteerRepository.existsByEmail(new VolunteerEmail(email));
+        return CheckDuplicateVolunteerEmailResponse.from(isDuplicated);
+    }
 
     @Transactional
     public Long registerVolunteer(

--- a/src/main/java/com/clova/anifriends/global/config/SecurityConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/volunteers/*/recruitments/completed").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/shelters/*/recruitments").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/volunteers/*/reviews").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/volunteers/email").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/shelters/email").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/volunteers").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/shelters").permitAll()
                     .requestMatchers("/api/shelters/**").hasRole(ROLE_SHELTER)

--- a/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
@@ -1,10 +1,13 @@
 package com.clova.anifriends.domain.shelter.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -12,6 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateShelterEmailRequest;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateShelterResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
@@ -23,6 +28,36 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ShelterControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("보호소 이메일 중복 확인 api 호출 시")
+    void checkDuplicateShelterEmail() throws Exception {
+        //given
+        CheckDuplicateShelterEmailRequest checkDuplicateShelterEmailRequest
+            = new CheckDuplicateShelterEmailRequest("email@email.com");
+        CheckDuplicateShelterResponse checkDuplicateShelterResponse
+            = new CheckDuplicateShelterResponse(true);
+
+        given(shelterService.checkDuplicateEmail(anyString())).willReturn(
+            checkDuplicateShelterResponse);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/shelters/email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(checkDuplicateShelterEmailRequest)));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("email").type(JsonFieldType.STRING).description("보호소 이메일")
+                ),
+                responseFields(
+                    fieldWithPath("isDuplicated").type(JsonFieldType.BOOLEAN)
+                        .description("이메일 중복 여부")
+                )
+            ));
+    }
 
     @Test
     @DisplayName("findShelterDetail 실행 시")

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.ShelterImage;
-import com.clova.anifriends.domain.shelter.dto.CheckDuplicateEmailResponse;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateShelterResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
@@ -49,7 +49,7 @@ class ShelterServiceTest {
             given(shelterRepository.existsByEmail(any())).willReturn(true);
 
             //when
-            CheckDuplicateEmailResponse response
+            CheckDuplicateShelterResponse response
                 = shelterService.checkDuplicateEmail(email);
 
             //then

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterServiceTest.java
@@ -2,11 +2,13 @@ package com.clova.anifriends.domain.shelter.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.ShelterImage;
+import com.clova.anifriends.domain.shelter.dto.CheckDuplicateEmailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
@@ -33,6 +35,27 @@ class ShelterServiceTest {
 
     Shelter givenShelter;
     ShelterImage givenShelterImage;
+
+    @Nested
+    @DisplayName("checkDuplicateEmail 실행 시")
+    class CheckDuplicateEmailTest {
+
+        @Test
+        @DisplayName("성공")
+        void checkDuplicateEmail() {
+            //given
+            String email = "email@email.com";
+
+            given(shelterRepository.existsByEmail(any())).willReturn(true);
+
+            //when
+            CheckDuplicateEmailResponse response
+                = shelterService.checkDuplicateEmail(email);
+
+            //then
+            assertThat(response.isDuplicated()).isTrue();
+        }
+    }
 
     @Nested
     @DisplayName("findShelterDetail 실행 시")

--- a/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
@@ -2,11 +2,13 @@ package com.clova.anifriends.domain.volunteer.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -18,9 +20,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.clova.anifriends.base.BaseControllerTest;
+import com.clova.anifriends.docs.format.DocumentationFormatGenerator;
 import com.clova.anifriends.domain.applicant.wrapper.ApplicantStatus;
 import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.dto.request.CheckDuplicateVolunteerEmailRequest;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
+import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
 import com.clova.anifriends.domain.volunteer.support.VolunteerDtoFixture;
@@ -32,6 +37,36 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 class VolunteerControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("봉사자 이메일 중복 확인 API 호출 시")
+    void checkDuplicateVolunteerEmail() throws Exception {
+        //given
+        CheckDuplicateVolunteerEmailRequest checkDuplicateVolunteerEmailRequest
+            = VolunteerDtoFixture.checkDuplicateVolunteerEmailRequest();
+        CheckDuplicateVolunteerEmailResponse checkDuplicateVolunteerEmailResponse
+            = new CheckDuplicateVolunteerEmailResponse(false);
+
+        given(volunteerService.checkDuplicateVolunteerEmail(anyString()))
+            .willReturn(checkDuplicateVolunteerEmailResponse);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/volunteers/email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(checkDuplicateVolunteerEmailRequest)));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("email").type(STRING).description("사용자 이메일")
+                        .attributes(DocumentationFormatGenerator.getConstraint("@를 포함한 이메일 형식"))
+                ),
+                responseFields(
+                    fieldWithPath("isDuplicated").type(BOOLEAN).description("이메일 중복 여부")
+                )
+            ));
+    }
 
     @Test
     @DisplayName("봉사자 회원가입 API 호출 시")

--- a/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerServiceTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
+import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
@@ -33,6 +34,27 @@ class VolunteerServiceTest {
 
     @Mock
     VolunteerRepository volunteerRepository;
+
+    @Nested
+    @DisplayName("checkDuplicateVolunteerEmail 메서드 실행 시")
+    class CheckDuplicateVolunteerEmailTest {
+
+        @Test
+        @DisplayName("성공")
+        void checkDuplicateVolunteerEmail() {
+            //given
+            String email = "email@email.com";
+
+            given(volunteerRepository.existsByEmail(any())).willReturn(true);
+
+            //when
+            CheckDuplicateVolunteerEmailResponse response
+                = volunteerService.checkDuplicateVolunteerEmail(email);
+
+            //then
+            assertThat(response.isDuplicated()).isTrue();
+        }
+    }
 
     @Nested
     @DisplayName("registerVolunteer 메서드 실행 시")

--- a/src/test/java/com/clova/anifriends/domain/volunteer/support/VolunteerDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/support/VolunteerDtoFixture.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.volunteer.support;
 
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
+import com.clova.anifriends.domain.volunteer.dto.request.CheckDuplicateVolunteerEmailRequest;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
 import com.clova.anifriends.domain.volunteer.wrapper.VolunteerGender;
 
@@ -24,6 +25,10 @@ public class VolunteerDtoFixture {
     public static RegisterVolunteerRequest registerVolunteerRequest() {
         return new RegisterVolunteerRequest(EMAIL, PASSWORD, NAME, BIRTH_DATE, PHONE_NUMBER,
             GENDER);
+    }
+
+    public static CheckDuplicateVolunteerEmailRequest checkDuplicateVolunteerEmailRequest() {
+        return new CheckDuplicateVolunteerEmailRequest(EMAIL);
     }
 }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자와 보호소의 이메일 중복 확인 API를 각각 구현하였습니다.

### 📝 작업 요약
- 봉사자 이메일 중복 확인 API, 서비스 로직, 쿼리를 구현하였습니다.
- 보호소 이메일 중복 확인 API, 서비스 로직, 쿼리를 구현하였습니다.


### 💡 관련 이슈
- close #141 
