### PR TITLE
feat: 보호 동물 검색 조회 로직을 구현한다.(봉사자)

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/animal/AnimalAge.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/AnimalAge.java
@@ -3,10 +3,10 @@ package com.clova.anifriends.domain.animal;
 import com.clova.anifriends.domain.common.EnumType;
 
 public enum AnimalAge implements EnumType {
-    BABY(0, 6),
-    JUNIOR(7, 35),
-    ADULT(36, 83),
-    SENIOR(84, Integer.MAX_VALUE);
+    BABY(0, 7),
+    JUNIOR(7, 36),
+    ADULT(36, 108),
+    SENIOR(108, Integer.MAX_VALUE);
 
     private final int minMonth;
     private final int maxMonth;

--- a/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
@@ -1,10 +1,12 @@
 package com.clova.anifriends.domain.animal.controller;
 
 import com.clova.anifriends.domain.animal.dto.request.FindAnimalsByShelterRequest;
+import com.clova.anifriends.domain.animal.dto.request.FindAnimalsByVolunteerRequest;
 import com.clova.anifriends.domain.animal.dto.request.RegisterAnimalRequest;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalByShelterResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalByVolunteerResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByShelterResponse;
+import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByVolunteerResponse;
 import com.clova.anifriends.domain.animal.dto.response.RegisterAnimalResponse;
 import com.clova.anifriends.domain.animal.service.AnimalService;
 import com.clova.anifriends.domain.auth.resolver.LoginUser;
@@ -66,6 +68,22 @@ public class AnimalController {
             findAnimalsByShelterRequest.active(),
             findAnimalsByShelterRequest.size(),
             findAnimalsByShelterRequest.age(),
+            pageable
+        ));
+    }
+
+    @GetMapping("/volunteers/animals")
+    public ResponseEntity<FindAnimalsByVolunteerResponse> findAnimalsByVolunteer(
+        Pageable pageable,
+        @ModelAttribute FindAnimalsByVolunteerRequest findAnimalsByVolunteerRequest
+    ) {
+        return ResponseEntity.ok(animalService.findAnimalsByVolunteer(
+            findAnimalsByVolunteerRequest.type(),
+            findAnimalsByVolunteerRequest.active(),
+            findAnimalsByVolunteerRequest.isNeutered(),
+            findAnimalsByVolunteerRequest.age(),
+            findAnimalsByVolunteerRequest.gender(),
+            findAnimalsByVolunteerRequest.size(),
             pageable
         ));
     }

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/request/FindAnimalsByVolunteerRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/request/FindAnimalsByVolunteerRequest.java
@@ -1,0 +1,18 @@
+package com.clova.anifriends.domain.animal.dto.request;
+
+import com.clova.anifriends.domain.animal.AnimalAge;
+import com.clova.anifriends.domain.animal.AnimalSize;
+import com.clova.anifriends.domain.animal.wrapper.AnimalActive;
+import com.clova.anifriends.domain.animal.wrapper.AnimalGender;
+import com.clova.anifriends.domain.animal.wrapper.AnimalType;
+
+public record FindAnimalsByVolunteerRequest(
+    AnimalType type,
+    AnimalGender gender,
+    Boolean isNeutered,
+    AnimalActive active,
+    AnimalSize size,
+    AnimalAge age
+) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/response/FindAnimalsByVolunteerResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/response/FindAnimalsByVolunteerResponse.java
@@ -1,0 +1,40 @@
+package com.clova.anifriends.domain.animal.dto.response;
+
+import com.clova.anifriends.domain.animal.Animal;
+import com.clova.anifriends.domain.common.PageInfo;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record FindAnimalsByVolunteerResponse(
+    PageInfo pageInfo,
+    List<FindAnimalByVolunteerResponse> animals
+) {
+
+    public record FindAnimalByVolunteerResponse(
+        Long animalId,
+        String animalName,
+        String shelterName,
+        String shelterAddress,
+        String animalImageUrl
+    ) {
+
+        public static FindAnimalByVolunteerResponse from(Animal animal) {
+            return new FindAnimalByVolunteerResponse(
+                animal.getAnimalId(),
+                animal.getName(),
+                animal.getShelter().getName(),
+                animal.getShelter().getAddress(),
+                animal.getImageUrls().get(0)
+            );
+        }
+    }
+
+    public static FindAnimalsByVolunteerResponse from(Page<Animal> pagination) {
+        PageInfo pageInfo = PageInfo.of(pagination.getTotalElements(), pagination.hasNext());
+        List<FindAnimalByVolunteerResponse> findAnimalByVolunteerResponses = pagination.get()
+            .map(FindAnimalByVolunteerResponse::from).toList();
+
+        return new FindAnimalsByVolunteerResponse(pageInfo, findAnimalByVolunteerResponses);
+    }
+
+}

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryCustom.java
@@ -22,4 +22,14 @@ public interface AnimalRepositoryCustom {
         AnimalAge age,
         Pageable pageable
     );
+
+    Page<Animal> findAnimalsByVolunteer(
+        AnimalType type,
+        AnimalActive active,
+        Boolean isNeutered,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
@@ -68,7 +68,7 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
             )
             .fetchOne();
 
-        return new PageImpl<>(animals, pageable, count);
+        return new PageImpl<>(animals, pageable, count == null ? 0 : count);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        int count = query.select(animal.count())
+        Long count = query.select(animal.count())
             .from(animal)
             .join(animal.shelter)
             .where(
@@ -107,10 +107,9 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
                 animalGenderContains(gender),
                 animalSizeContains(size)
             )
-            .fetch()
-            .size();
+            .fetchOne();
 
-        return new PageImpl<>(animals, pageable, count);
+        return new PageImpl<>(animals, pageable, count == null ? 0 : count);
     }
 
     private BooleanExpression animalNameContains(String keyword) {

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
@@ -70,6 +70,47 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
         return new PageImpl<>(animals, pageable, count);
     }
 
+    @Override
+    public Page<Animal> findAnimalsByVolunteer(
+        AnimalType type,
+        AnimalActive active,
+        Boolean isNeutered,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size,
+        Pageable pageable
+    ) {
+        List<Animal> animals = query.selectFrom(animal)
+            .join(animal.shelter)
+            .where(
+                animalTypeContains(type),
+                animalActiveContains(active),
+                animalIsNeutered(isNeutered),
+                animalAgeContains(age),
+                animalGenderContains(gender),
+                animalSizeContains(size)
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        int count = query.select(animal.count())
+            .from(animal)
+            .join(animal.shelter)
+            .where(
+                animalTypeContains(type),
+                animalActiveContains(active),
+                animalIsNeutered(isNeutered),
+                animalAgeContains(age),
+                animalGenderContains(gender),
+                animalSizeContains(size)
+            )
+            .fetch()
+            .size();
+
+        return new PageImpl<>(animals, pageable, count);
+    }
+
     private BooleanExpression animalNameContains(String keyword) {
         return keyword != null ? animal.name.name.contains(keyword) : null;
     }
@@ -77,25 +118,25 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
     private BooleanExpression animalTypeContains(
         AnimalType type
     ) {
-        return type != null ? animal.type.stringValue().eq(type.getName()) : null;
+        return type != null ? animal.type.eq(type) : null;
     }
 
     private BooleanExpression animalGenderContains(
         AnimalGender gender
     ) {
-        return gender != null ? animal.gender.stringValue().eq(gender.getName()) : null;
+        return gender != null ? animal.gender.eq(gender) : null;
     }
 
     private BooleanExpression animalIsNeutered(
-        Boolean isNeuteredFilter
+        Boolean isNeutered
     ) {
-        return isNeuteredFilter != null ? animal.neutered.isNeutered.eq(isNeuteredFilter) : null;
+        return isNeutered != null ? animal.neutered.isNeutered.eq(isNeutered) : null;
     }
 
     private BooleanExpression animalActiveContains(
         AnimalActive active
     ) {
-        return active != null ? animal.active.stringValue().contains(active.getName()) : null;
+        return active != null ? animal.active.eq(active) : null;
     }
 
     private BooleanExpression animalSizeContains(
@@ -108,7 +149,8 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
         int minWeight = size.getMinWeight();
         int maxWeight = size.getMaxWeight();
 
-        return animal.weight.weight.between(minWeight, maxWeight);
+        return animal.weight.weight.goe(minWeight)
+            .and(animal.weight.weight.lt(maxWeight));
     }
 
     private BooleanExpression animalAgeContains(
@@ -125,6 +167,7 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
         LocalDate minDate = currentDate.minusMonths(minMonth);
         LocalDate maxDate = currentDate.minusMonths(maxMonth);
 
-        return animal.birthDate.between(maxDate, minDate);
+        return animal.birthDate.gt(maxDate)
+            .and(animal.birthDate.loe(minDate));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
@@ -49,6 +49,7 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
                 animalSizeContains(size),
                 animalAgeContains(age)
             )
+            .orderBy(animal.createdAt.desc())
             .limit(pageable.getPageSize())
             .offset(pageable.getOffset())
             .fetch();
@@ -90,6 +91,7 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
                 animalGenderContains(gender),
                 animalSizeContains(size)
             )
+            .orderBy(animal.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
@@ -7,6 +7,7 @@ import com.clova.anifriends.domain.animal.dto.request.RegisterAnimalRequest;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalByShelterResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalByVolunteerResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByShelterResponse;
+import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByVolunteerResponse;
 import com.clova.anifriends.domain.animal.dto.response.RegisterAnimalResponse;
 import com.clova.anifriends.domain.animal.exception.AnimalNotFoundException;
 import com.clova.anifriends.domain.animal.mapper.AnimalMapper;
@@ -80,6 +81,29 @@ public class AnimalService {
         );
 
         return FindAnimalsByShelterResponse.from(animals);
+    }
+
+
+    public FindAnimalsByVolunteerResponse findAnimalsByVolunteer(
+        AnimalType type,
+        AnimalActive active,
+        Boolean isNeutered,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size,
+        Pageable pageable
+    ) {
+        Page<Animal> animalsWithPagination = animalRepository.findAnimalsByVolunteer(
+            type,
+            active,
+            isNeutered,
+            age,
+            gender,
+            size,
+            pageable
+        );
+
+        return FindAnimalsByVolunteerResponse.from(animalsWithPagination);
     }
 
     private Animal getAnimalById(Long animalId) {

--- a/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImplTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImplTest.java
@@ -175,5 +175,296 @@ class AnimalRepositoryImplTest extends BaseRepositoryTest {
             // then
             assertThat(expected.getTotalElements()).isEqualTo(1);
         }
+
+        @Test
+        @DisplayName("성공: 이름 일치, 크기는 최소 경계값")
+        void findAnimalsWhenNameIsSameAndSizeIsMinBoundary() {
+            // given
+            String mockInformation = "animalInformation";
+            String mockBreed = "animalBreed";
+            List<String> mockImageUrls = List.of("www.aws.s3.com/2");
+
+            String keyword = "animalName";
+            AnimalSize sizeFilter = AnimalSize.MEDIUM;
+
+            AnimalType nullTypeFilter = null;
+            AnimalActive nullActiveFilter = null;
+            Boolean nullIsNeuteredFilter = null;
+            AnimalAge nullAgeFilter = null;
+            AnimalGender nullGenderFilter = null;
+
+            Shelter shelter = ShelterFixture.shelter();
+
+            Animal matchAnimal1 = new Animal(
+                shelter,
+                keyword,
+                LocalDate.now(),
+                AnimalType.DOG.getName(),
+                mockBreed,
+                AnimalGender.MALE.getName(),
+                true,
+                AnimalActive.ACTIVE.getName(),
+                AnimalSize.MEDIUM.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            Animal misMatchAnimal1 = new Animal(
+                shelter,
+                keyword,
+                LocalDate.now(),
+                AnimalType.DOG.getName(),
+                mockBreed,
+                AnimalGender.MALE.getName(),
+                true,
+                AnimalActive.ACTIVE.getName(),
+                AnimalSize.MEDIUM.getMinWeight() - 1,
+                mockInformation,
+                mockImageUrls
+            );
+
+            shelterRepository.save(shelter);
+            animalRepository.saveAll(List.of(matchAnimal1, misMatchAnimal1));
+
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            // when
+            Page<Animal> result = customAnimalRepository.findAnimalsByShelter(
+                shelter.getShelterId(),
+                keyword,
+                nullTypeFilter,
+                nullGenderFilter,
+                nullIsNeuteredFilter,
+                nullActiveFilter,
+                sizeFilter,
+                nullAgeFilter,
+                pageRequest
+            );
+
+            // then
+            assertThat(result.getContent()).containsExactlyInAnyOrder(matchAnimal1);
+        }
+
+        @Test
+        @DisplayName("성공: 이름 일치, 크기는 최대 경계값")
+        void findAnimalsWhenNameIsSameAndSizeIsMaxBoundary() {
+            // given
+            String mockInformation = "animalInformation";
+            String mockBreed = "animalBreed";
+            List<String> mockImageUrls = List.of("www.aws.s3.com/2");
+
+            String keyword = "animalName";
+            AnimalSize sizeFilter = AnimalSize.MEDIUM;
+
+            AnimalType nullTypeFilter = null;
+            AnimalActive nullActiveFilter = null;
+            Boolean nullIsNeuteredFilter = null;
+            AnimalAge nullAgeFilter = null;
+            AnimalGender nullGenderFilter = null;
+
+            Shelter shelter = ShelterFixture.shelter();
+
+            Animal matchAnimal1 = new Animal(
+                shelter,
+                keyword,
+                LocalDate.now(),
+                AnimalType.DOG.getName(),
+                mockBreed,
+                AnimalGender.MALE.getName(),
+                true,
+                AnimalActive.ACTIVE.getName(),
+                AnimalSize.MEDIUM.getMaxWeight() - 1,
+                mockInformation,
+                mockImageUrls
+            );
+
+            Animal misMatchAnimal1 = new Animal(
+                shelter,
+                keyword,
+                LocalDate.now(),
+                AnimalType.DOG.getName(),
+                mockBreed,
+                AnimalGender.MALE.getName(),
+                true,
+                AnimalActive.ACTIVE.getName(),
+                AnimalSize.MEDIUM.getMaxWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            shelterRepository.save(shelter);
+            animalRepository.saveAll(List.of(matchAnimal1, misMatchAnimal1));
+
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            // when
+            Page<Animal> result = customAnimalRepository.findAnimalsByShelter(
+                shelter.getShelterId(),
+                keyword,
+                nullTypeFilter,
+                nullGenderFilter,
+                nullIsNeuteredFilter,
+                nullActiveFilter,
+                sizeFilter,
+                nullAgeFilter,
+                pageRequest
+            );
+
+            // then
+            assertThat(result.getContent()).containsExactlyInAnyOrder(matchAnimal1);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("findAnimalsByVolunteer 실행 시")
+    class FindAnimalsByVolunteerTest {
+
+        @Test
+        @DisplayName("성공: 모든 필터링이 존재")
+        void allFilterExist() {
+            // given
+            String mockName = "animalName";
+            String mockInformation = "animalInformation";
+            String mockBreed = "animalBreed";
+            List<String> mockImageUrls = List.of("www.aws.s3.com/2");
+
+            AnimalType typeFilter = AnimalType.DOG;
+            AnimalActive activeFilter = AnimalActive.ACTIVE;
+            Boolean isNeuteredFilter = true;
+            AnimalAge ageFilter = AnimalAge.ADULT;
+            AnimalGender genderFilter = AnimalGender.MALE;
+            AnimalSize sizeFilter = AnimalSize.MEDIUM;
+
+            Shelter shelter = ShelterFixture.shelter();
+
+            Animal matchAnimal1 = new Animal(
+                shelter,
+                mockName,
+                LocalDate.now().minusMonths(ageFilter.getMinMonth()),
+                typeFilter.getName(),
+                mockBreed,
+                genderFilter.getName(),
+                isNeuteredFilter,
+                activeFilter.getName(),
+                sizeFilter.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            Animal matchAnimal2 = new Animal(
+                shelter,
+                mockName,
+                LocalDate.now().minusMonths(ageFilter.getMinMonth()),
+                typeFilter.getName(),
+                mockBreed,
+                genderFilter.getName(),
+                isNeuteredFilter,
+                activeFilter.getName(),
+                sizeFilter.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            Animal disMatchAnimal1 = new Animal(
+                shelter,
+                mockName,
+                LocalDate.now().minusMonths(ageFilter.getMinMonth()),
+                typeFilter.getName(),
+                mockBreed,
+                genderFilter.getName(),
+                isNeuteredFilter ? false : true,
+                activeFilter.getName(),
+                sizeFilter.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            shelterRepository.save(shelter);
+            animalRepository.saveAll(List.of(matchAnimal1, matchAnimal2, disMatchAnimal1));
+
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            // when
+            Page<Animal> result = customAnimalRepository.findAnimalsByVolunteer(
+                typeFilter,
+                activeFilter,
+                isNeuteredFilter,
+                ageFilter,
+                genderFilter,
+                sizeFilter,
+                pageRequest
+            );
+
+            // then
+            assertThat(result.getContent()).containsExactlyInAnyOrder(matchAnimal1, matchAnimal2);
+        }
+
+        @Test
+        @DisplayName("성공: 모든 필터링이 존재하지 않음")
+        void allFilterNotExist() {
+            // given
+            String mockName = "animalName";
+            String mockInformation = "animalInformation";
+            String mockBreed = "animalBreed";
+            List<String> mockImageUrls = List.of("www.aws.s3.com/2");
+
+            AnimalType nullTypeFilter = null;
+            AnimalActive nullActiveFilter = null;
+            Boolean nullIsNeuteredFilter = null;
+            AnimalAge nullAgeFilter = null;
+            AnimalGender nullGenderFilter = null;
+            AnimalSize nullSizeFilter = null;
+
+            Shelter shelter = ShelterFixture.shelter();
+
+            Animal matchAnimal1 = new Animal(
+                shelter,
+                mockName,
+                LocalDate.now(),
+                AnimalType.DOG.getName(),
+                mockBreed,
+                AnimalGender.MALE.getName(),
+                true,
+                AnimalActive.ACTIVE.getName(),
+                AnimalSize.LARGE.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            Animal matchAnimal2 = new Animal(
+                shelter,
+                mockName,
+                LocalDate.now(),
+                AnimalType.ETC.getName(),
+                mockBreed,
+                AnimalGender.FEMALE.getName(),
+                true,
+                AnimalActive.NORMAL.getName(),
+                AnimalSize.MEDIUM.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            shelterRepository.save(shelter);
+            animalRepository.saveAll(List.of(matchAnimal1, matchAnimal2));
+
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            // when
+            Page<Animal> result = customAnimalRepository.findAnimalsByVolunteer(
+                nullTypeFilter,
+                nullActiveFilter,
+                nullIsNeuteredFilter,
+                nullAgeFilter,
+                nullGenderFilter,
+                nullSizeFilter,
+                pageRequest
+            );
+
+            // then
+            assertThat(result.getContent()).containsExactlyInAnyOrder(matchAnimal1, matchAnimal2);
+        }
+
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceTest.java
@@ -18,6 +18,7 @@ import com.clova.anifriends.domain.animal.dto.request.RegisterAnimalRequest;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalByShelterResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalByVolunteerResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByShelterResponse;
+import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByVolunteerResponse;
 import com.clova.anifriends.domain.animal.exception.AnimalNotFoundException;
 import com.clova.anifriends.domain.animal.repository.AnimalRepository;
 import com.clova.anifriends.domain.animal.wrapper.AnimalActive;
@@ -216,6 +217,63 @@ class AnimalServiceTest {
 
             // then
             assertThat(expected).usingRecursiveComparison().isEqualTo(animalsByShelter);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAnimalsByVolunteer 실행 시")
+    class FindAnimalsByVolunteer {
+
+        @Test
+        @DisplayName("성공")
+        void findAnimalsByVolunteer() {
+            // given
+            String mockName = "animalName";
+            String mockInformation = "animalInformation";
+            String mockBreed = "animalBreed";
+            List<String> mockImageUrls = List.of("www.aws.s3.com/2");
+
+            AnimalType typeFilter = AnimalType.DOG;
+            AnimalActive activeFilter = AnimalActive.ACTIVE;
+            Boolean isNeuteredFilter = true;
+            AnimalAge ageFilter = AnimalAge.ADULT;
+            AnimalGender genderFilter = AnimalGender.MALE;
+            AnimalSize sizeFilter = AnimalSize.MEDIUM;
+
+            Shelter shelter = ShelterFixture.shelter();
+
+            Animal matchAnimal = new Animal(
+                shelter,
+                mockName,
+                LocalDate.now().minusMonths(ageFilter.getMinMonth()),
+                typeFilter.getName(),
+                mockBreed,
+                genderFilter.getName(),
+                isNeuteredFilter,
+                activeFilter.getName(),
+                sizeFilter.getMinWeight(),
+                mockInformation,
+                mockImageUrls
+            );
+
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Page<Animal> pageResult = new PageImpl<>(List.of(matchAnimal), pageRequest, 1);
+
+            FindAnimalsByVolunteerResponse expected = FindAnimalsByVolunteerResponse.from(
+                pageResult);
+
+            when(animalRepository.findAnimalsByVolunteer(typeFilter, activeFilter, isNeuteredFilter,
+                ageFilter, genderFilter, sizeFilter, pageRequest))
+                .thenReturn(pageResult);
+
+            // when
+            FindAnimalsByVolunteerResponse result = animalService.findAnimalsByVolunteer(
+                typeFilter, activeFilter, isNeuteredFilter,
+                ageFilter, genderFilter, sizeFilter, pageRequest);
+
+            // then
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
봉사자 입장의 보호 동물 검색 조회 로직을 구현했습니다.

### 📝 작업 요약
- 보호 동물 필터링 검색을 위한 동적 쿼리 구현
- 레포지토리 테스트코드 작성
- 보호 동물 검색 조회 서비스 구현
- 보호 동물 검색 조회 서비스 테스트코드 작성
- 보호 동물 검색 조회 컨트롤러 구현
- 보호 동물 검색 조회 컨트롤러 테스트코드 작성

### 💡 관련 이슈
- close #67 
