### PR TITLE
refactor: 봉사자가 신청한 봉사 리스트 조회(봉사자)를 명세에 맞게 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/dto/FindApplyingVolunteersResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/dto/FindApplyingVolunteersResponse.java
@@ -12,11 +12,11 @@ public record FindApplyingVolunteersResponse(
     public record FindApplyingVolunteerResponse(
         Long recruitmentId,
         Long applicantId,
-        String title,
+        String recruitmentTitle,
         String shelterName,
-        ApplicantStatus status,
-        boolean isWritedReview,
-        LocalDateTime volunteerDate
+        ApplicantStatus applicantStatus,
+        boolean applicantIsWritedReview,
+        LocalDateTime recruitmentStartTime
     ) {
 
         public static FindApplyingVolunteerResponse from(

--- a/src/main/java/com/clova/anifriends/domain/applicant/dto/FindApplyingVolunteersResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/dto/FindApplyingVolunteersResponse.java
@@ -10,6 +10,7 @@ public record FindApplyingVolunteersResponse(
 ) {
 
     public record FindApplyingVolunteerResponse(
+        Long shelterId,
         Long recruitmentId,
         Long applicantId,
         String recruitmentTitle,
@@ -23,6 +24,7 @@ public record FindApplyingVolunteersResponse(
             Applicant applicant
         ) {
             return new FindApplyingVolunteerResponse(
+                applicant.getRecruitment().getShelter().getShelterId(),
                 applicant.getRecruitment().getRecruitmentId(),
                 applicant.getApplicantId(),
                 applicant.getRecruitment().getTitle(),

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -66,12 +66,14 @@ class ApplicantControllerTest extends BaseControllerTest {
     @DisplayName("findApplyingVolunteers 실행 시")
     void findApplyingVolunteers() throws Exception {
         // given
+        Long shelterId = 1L;
         Long volunteerId = 1L;
         Long recruitmentId = 1L;
         Long applicantShouldWriteReviewId = 1L;
         Long applicantShouldNotWriteReviewId = 2L;
 
         Shelter shelter = ShelterFixture.shelter();
+        setField(shelter, "shelterId", shelterId);
         Volunteer volunteer = VolunteerFixture.volunteer();
         setField(volunteer, "volunteerId", volunteerId);
 
@@ -111,6 +113,9 @@ class ApplicantControllerTest extends BaseControllerTest {
                 responseFields(
                     fieldWithPath("findApplyingVolunteerResponses").type(JsonFieldType.ARRAY)
                         .description("신청한 봉사 리스트"),
+                    fieldWithPath("findApplyingVolunteerResponses[].shelterId").type(
+                            JsonFieldType.NUMBER)
+                        .description("보호소 ID"),
                     fieldWithPath("findApplyingVolunteerResponses[].recruitmentId").type(
                             JsonFieldType.NUMBER)
                         .description("봉사 모집글 ID"),

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -117,19 +117,19 @@ class ApplicantControllerTest extends BaseControllerTest {
                     fieldWithPath("findApplyingVolunteerResponses[].applicantId").type(
                             JsonFieldType.NUMBER)
                         .description("봉사 신청자 ID"),
-                    fieldWithPath("findApplyingVolunteerResponses[].title").type(
+                    fieldWithPath("findApplyingVolunteerResponses[].recruitmentTitle").type(
                             JsonFieldType.STRING)
                         .description("모집글 제목"),
                     fieldWithPath("findApplyingVolunteerResponses[].shelterName").type(
                             JsonFieldType.STRING)
                         .description("보호소 이름"),
-                    fieldWithPath("findApplyingVolunteerResponses[].status").type(
+                    fieldWithPath("findApplyingVolunteerResponses[].applicantStatus").type(
                             JsonFieldType.STRING)
                         .description("승인 상태"),
-                    fieldWithPath("findApplyingVolunteerResponses[].isWritedReview").type(
+                    fieldWithPath("findApplyingVolunteerResponses[].applicantIsWritedReview").type(
                             JsonFieldType.BOOLEAN)
                         .description("후기 작성 가능 여부"),
-                    fieldWithPath("findApplyingVolunteerResponses[].volunteerDate").type(
+                    fieldWithPath("findApplyingVolunteerResponses[].recruitmentStartTime").type(
                             JsonFieldType.STRING)
                         .description("봉사 날짜")
                 )

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -145,14 +145,11 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
 
             // then
             assertThat(expected.findApplyingVolunteerResponses().get(0)
-                .applicantIsWritedReview()).isEqualTo(
-                true);
+                .applicantIsWritedReview()).isTrue();
             assertThat(expected.findApplyingVolunteerResponses().get(1)
-                .applicantIsWritedReview()).isEqualTo(
-                false);
+                .applicantIsWritedReview()).isFalse();
             assertThat(expected.findApplyingVolunteerResponses().get(2)
-                .applicantIsWritedReview()).isEqualTo(
-                false);
+                .applicantIsWritedReview()).isFalse();
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -144,11 +144,14 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
                 applyingVolunteers);
 
             // then
-            assertThat(expected.findApplyingVolunteerResponses().get(0).isWritedReview()).isEqualTo(
+            assertThat(expected.findApplyingVolunteerResponses().get(0)
+                .applicantIsWritedReview()).isEqualTo(
                 true);
-            assertThat(expected.findApplyingVolunteerResponses().get(1).isWritedReview()).isEqualTo(
+            assertThat(expected.findApplyingVolunteerResponses().get(1)
+                .applicantIsWritedReview()).isEqualTo(
                 false);
-            assertThat(expected.findApplyingVolunteerResponses().get(2).isWritedReview()).isEqualTo(
+            assertThat(expected.findApplyingVolunteerResponses().get(2)
+                .applicantIsWritedReview()).isEqualTo(
                 false);
         }
     }

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -193,13 +193,13 @@ class ApplicantServiceTest {
 
             // then
             assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(0)
-                .isWritedReview()).isEqualTo(
+                .applicantIsWritedReview()).isEqualTo(
                 findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(0)
-                    .isWritedReview());
+                    .applicantIsWritedReview());
             assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(1)
-                .isWritedReview()).isEqualTo(
+                .applicantIsWritedReview()).isEqualTo(
                 findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(1)
-                    .isWritedReview());
+                    .applicantIsWritedReview());
         }
 
         @Test
@@ -231,13 +231,13 @@ class ApplicantServiceTest {
 
             // then
             assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(0)
-                .isWritedReview()).isEqualTo(
+                .applicantIsWritedReview()).isEqualTo(
                 findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(0)
-                    .isWritedReview());
+                    .applicantIsWritedReview());
             assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(1)
-                .isWritedReview()).isEqualTo(
+                .applicantIsWritedReview()).isEqualTo(
                 findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(1)
-                    .isWritedReview());
+                    .applicantIsWritedReview());
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- API 명세에 맞게 FindApplyingVolunteerResponse에 shelterId 추가 및 응답 필드명 수정

### 📝 작업 요약
- 봉사자가 신청한 봉사 리스트 조회(봉사자)를 명세에 맞게 수정

### 💡 관련 이슈
- close #132 
