### PR TITLE
factor: 보호소에 달린 봉사 모집글 리스트 조회(공통)을 명세에 맞게 수정한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterIdResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterIdResponse.java
@@ -4,21 +4,24 @@ import com.clova.anifriends.domain.common.dto.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record FindRecruitmentsByShelterIdResponse(
     PageInfo pageInfo,
     List<RecruitmentResponse> recruitments
 ) {
     private record RecruitmentResponse(
-        String title,
-        LocalDateTime volunteerDate,
-        LocalDateTime deadline,
-        int capacity,
-        int applicantCount
+        long recruitmentId,
+        String recruitmentTitle,
+        LocalDateTime recruitmentStartTime,
+        LocalDateTime recruitmentDeadline,
+        int recruitmentCapacity,
+        int recruitmentApplicantCount
     ) {
 
         private static RecruitmentResponse from(Recruitment recruitment){
             return new RecruitmentResponse(
+                recruitment.getRecruitmentId(),
                 recruitment.getTitle(),
                 recruitment.getStartTime(),
                 recruitment.getDeadline(),
@@ -28,9 +31,9 @@ public record FindRecruitmentsByShelterIdResponse(
         }
     }
 
-    public static FindRecruitmentsByShelterIdResponse of(List<Recruitment> recruitments, PageInfo pageInfo) {
+    public static FindRecruitmentsByShelterIdResponse from(Page<Recruitment> recruitments) {
         return new FindRecruitmentsByShelterIdResponse(
-            pageInfo,
+            PageInfo.from(recruitments),
             recruitments.stream()
                 .map(RecruitmentResponse::from)
                 .toList()

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -134,7 +134,14 @@ public class RecruitmentRepositoryImpl implements
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
-        return new PageImpl<>(recruitments);
+
+        Long count = query.select(recruitment.count())
+            .from(recruitment)
+            .where(recruitment.shelter.shelterId.eq(shelterId)
+                .and(recruitment.info.isClosed.eq(false)))
+            .fetchOne();
+
+        return new PageImpl<>(recruitments, pageable, count == null ? 0 : count);
     }
 
     Predicate getDateCondition(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -84,8 +84,7 @@ public class RecruitmentService {
         Page<Recruitment> pagination = recruitmentRepository.findRecruitmentsByShelterId(
             shelterId, pageable
         );
-        return FindRecruitmentsByShelterIdResponse.of(pagination.getContent(),
-            PageInfo.from(pagination));
+        return FindRecruitmentsByShelterIdResponse.from(pagination);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -333,12 +333,13 @@ class RecruitmentControllerTest extends BaseControllerTest {
                     fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 게시글 수"),
                     fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부"),
                     fieldWithPath("recruitments[]").type(ARRAY).description("모집 게시글 리스트"),
-                    fieldWithPath("recruitments[].title").type(STRING).description("모집 제목"),
-                    fieldWithPath("recruitments[].volunteerDate").type(STRING)
+                    fieldWithPath("recruitments[].recruitmentId").type(NUMBER).description("모집 ID"),
+                    fieldWithPath("recruitments[].recruitmentTitle").type(STRING).description("모집 제목"),
+                    fieldWithPath("recruitments[].recruitmentStartTime").type(STRING)
                         .description("봉사 시작 시간"),
-                    fieldWithPath("recruitments[].deadline").type(STRING).description("모집 마감 시간"),
-                    fieldWithPath("recruitments[].capacity").type(NUMBER).description("모집 정원"),
-                    fieldWithPath("recruitments[].applicantCount").type(NUMBER)
+                    fieldWithPath("recruitments[].recruitmentDeadline").type(STRING).description("모집 마감 시간"),
+                    fieldWithPath("recruitments[].recruitmentCapacity").type(NUMBER).description("모집 정원"),
+                    fieldWithPath("recruitments[].recruitmentApplicantCount").type(NUMBER)
                         .description("현재 지원자 수")
                 )
             ));

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class RecruitmentServiceTest {
@@ -213,6 +214,7 @@ class RecruitmentServiceTest {
             // given
             Shelter shelter = shelter();
             Recruitment recruitment = recruitment(shelter);
+            ReflectionTestUtils.setField(recruitment, "recruitmentId", 4L);
             Page<Recruitment> pageResult = new PageImpl<>(List.of(recruitment));
             FindRecruitmentsByShelterIdResponse expected = findRecruitmentsByShelterIdResponse(
                 pageResult);

--- a/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentDtoFixture.java
@@ -16,7 +16,7 @@ public class RecruitmentDtoFixture {
 
     public static FindRecruitmentsByShelterIdResponse findRecruitmentsByShelterIdResponse(
         Page<Recruitment> pageResult) {
-        return FindRecruitmentsByShelterIdResponse.of(pageResult.getContent(), PageInfo.from(pageResult));
+        return FindRecruitmentsByShelterIdResponse.from(pageResult);
     }
 
     public static FindRecruitmentDetailResponse findRecruitmentDetailResponse(


### PR DESCRIPTION
### ⛏ 작업 사항
보호소에 달린 봉사 모집글 리스트 조회(공통)을 명세에 맞게 수정한다. 

### 📝 작업 요약
- responseDTO 변경
- 레포지토리 함수에서 직접 count 계산하여 Page 객체에 넣어주기
- 테스트 코드 변경

### 💡 관련 이슈
- close #126 
