### PR TITLE
refactor: 마이페이지 조회(봉사자)를 명세에 맞게 수정한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/FindVolunteerMyPageResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/FindVolunteerMyPageResponse.java
@@ -5,17 +5,20 @@ import com.clova.anifriends.domain.volunteer.Volunteer;
 import java.time.LocalDate;
 
 public record FindVolunteerMyPageResponse(
-    String email,
-    String name,
-    LocalDate birthDate,
-    String phoneNumber,
-    int temperature,
-    long volunteerCount,
-    String imageUrl
+    long volunteerId,
+    String volunteerEmail,
+    String volunteerName,
+    LocalDate volunteerBirthDate,
+    String volunteerPhoneNumber,
+    int volunteerTemperature,
+    long completedVolunteerCount,
+    String volunteerImageUrl,
+    String volunteerGender
 ) {
 
     public static FindVolunteerMyPageResponse from(Volunteer volunteer) {
         return new FindVolunteerMyPageResponse(
+            volunteer.getVolunteerId(),
             volunteer.getEmail(),
             volunteer.getName(),
             volunteer.getBirthDate(),
@@ -24,7 +27,8 @@ public record FindVolunteerMyPageResponse(
             volunteer.getApplicants().stream()
                 .filter(applicant -> applicant.getStatus().equals(ApplicantStatus.ATTENDANCE))
                 .count(),
-            volunteer.getVolunteerImageUrl()
+            volunteer.getVolunteerImageUrl(),
+            volunteer.getGender()
         );
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
@@ -21,7 +21,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.docs.format.DocumentationFormatGenerator;
-import com.clova.anifriends.domain.applicant.wrapper.ApplicantStatus;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.dto.request.CheckDuplicateVolunteerEmailRequest;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
@@ -30,10 +29,10 @@ import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageRes
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
 import com.clova.anifriends.domain.volunteer.support.VolunteerDtoFixture;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
-import com.clova.anifriends.domain.volunteer.support.VolunteerImageFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
 class VolunteerControllerTest extends BaseControllerTest {
@@ -104,16 +103,9 @@ class VolunteerControllerTest extends BaseControllerTest {
     void findVolunteerMyPage() throws Exception {
         // given
         Volunteer volunteer = VolunteerFixture.volunteer();
-        FindVolunteerMyPageResponse findVolunteerMyPageResponse = new FindVolunteerMyPageResponse(
-            volunteer.getEmail(),
-            volunteer.getName(),
-            volunteer.getBirthDate(),
-            volunteer.getPhoneNumber(),
-            volunteer.getTemperature(),
-            volunteer.getApplicants().stream()
-                .filter(applicant -> applicant.getStatus().equals(ApplicantStatus.ATTENDANCE))
-                .count(),
-            VolunteerImageFixture.volunteerImage(volunteer).getImageUrl());
+        ReflectionTestUtils.setField(volunteer, "volunteerId", 1L);
+        FindVolunteerMyPageResponse findVolunteerMyPageResponse = VolunteerDtoFixture.findVolunteerMyPageResponse(volunteer);
+
         given(volunteerService.findVolunteerMyPage(anyLong())).willReturn(
             findVolunteerMyPageResponse);
 
@@ -128,13 +120,15 @@ class VolunteerControllerTest extends BaseControllerTest {
             .andDo(restDocs.document(
                 requestHeaders(headerWithName("Authorization").description("액세스 토큰")),
                 responseFields(
-                    fieldWithPath("email").type(STRING).description("이메일"),
-                    fieldWithPath("name").type(STRING).description("이름"),
-                    fieldWithPath("birthDate").type(STRING).description("생년월일"),
-                    fieldWithPath("phoneNumber").type(STRING).description("전화번호"),
-                    fieldWithPath("temperature").type(NUMBER).description("온도"),
-                    fieldWithPath("volunteerCount").type(NUMBER).description("봉사 횟수"),
-                    fieldWithPath("imageUrl").type(STRING).description("프로필 이미지 URL").optional()
+                    fieldWithPath("volunteerId").type(NUMBER).description("봉사자 ID"),
+                    fieldWithPath("volunteerEmail").type(STRING).description("이메일"),
+                    fieldWithPath("volunteerName").type(STRING).description("이름"),
+                    fieldWithPath("volunteerBirthDate").type(STRING).description("생년월일"),
+                    fieldWithPath("volunteerPhoneNumber").type(STRING).description("전화번호"),
+                    fieldWithPath("volunteerTemperature").type(NUMBER).description("온도"),
+                    fieldWithPath("completedVolunteerCount").type(NUMBER).description("봉사 횟수"),
+                    fieldWithPath("volunteerImageUrl").type(STRING).description("프로필 이미지 URL").optional(),
+                    fieldWithPath("volunteerGender").type(STRING).description("성별")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class VolunteerServiceTest {
@@ -96,6 +97,7 @@ class VolunteerServiceTest {
         void success() {
             // given
             volunteer = VolunteerFixture.volunteer();
+            ReflectionTestUtils.setField(volunteer, "volunteerId", 1L);
             volunteerImage = VolunteerImageFixture.volunteerImage(volunteer);
             setField(volunteer, "volunteerImage", volunteerImage);
             FindVolunteerMyPageResponse expected = FindVolunteerMyPageResponse.from(volunteer);

--- a/src/test/java/com/clova/anifriends/domain/volunteer/support/VolunteerDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/support/VolunteerDtoFixture.java
@@ -4,6 +4,7 @@ import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
 import com.clova.anifriends.domain.volunteer.dto.request.CheckDuplicateVolunteerEmailRequest;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
+import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.wrapper.VolunteerGender;
 
 public class VolunteerDtoFixture {
@@ -29,6 +30,10 @@ public class VolunteerDtoFixture {
 
     public static CheckDuplicateVolunteerEmailRequest checkDuplicateVolunteerEmailRequest() {
         return new CheckDuplicateVolunteerEmailRequest(EMAIL);
+    }
+
+    public static FindVolunteerMyPageResponse findVolunteerMyPageResponse(Volunteer volunteer) {
+        return FindVolunteerMyPageResponse.from(volunteer);
     }
 }
 


### PR DESCRIPTION
### ⛏ 작업 사항
마이페이지 조회(봉사자)를 명세에 맞게 수정한다. 

### 📝 작업 요약
- responseDTO 수정
- 테스트 코드 수정

### 💡 관련 이슈
- close #131 
