### PR TITLE
refactor: 모집글 조회 & 검색(보호소)를 명세에 맞게 수정한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
@@ -4,6 +4,7 @@ import com.clova.anifriends.domain.common.dto.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record FindRecruitmentsByShelterResponse(
     PageInfo pageInfo,
@@ -12,13 +13,13 @@ public record FindRecruitmentsByShelterResponse(
 ) {
     private record RecruitmentResponse(
        long recruitmentId,
-        String title,
-        LocalDateTime startTime,
-        LocalDateTime endTime,
-        LocalDateTime deadline,
-        boolean isClosed,
-        int applicantCount,
-        int capacity
+        String recruitmentTitle,
+        LocalDateTime recruitmentStartTime,
+        LocalDateTime recruitmentEndTime,
+        LocalDateTime recruitmentDeadline,
+        boolean recruitmentIsClosed,
+        int recruitmentApplicantCount,
+        int recruitmentCapacity
     ) {
         private static RecruitmentResponse from(Recruitment recruitment){
             return new RecruitmentResponse(
@@ -34,9 +35,9 @@ public record FindRecruitmentsByShelterResponse(
         }
     }
 
-    public static FindRecruitmentsByShelterResponse of(List<Recruitment> recruitments, PageInfo pageInfo){
+    public static FindRecruitmentsByShelterResponse from(Page<Recruitment> recruitments){
         return new FindRecruitmentsByShelterResponse(
-            pageInfo,
+            PageInfo.from(recruitments),
             recruitments.stream()
                 .map(RecruitmentResponse::from)
                 .toList()

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -121,7 +121,13 @@ public class RecruitmentRepositoryImpl implements
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
-        return new PageImpl<>(recruitments);
+
+        Long count = query.select(recruitment.count())
+            .from(recruitment)
+            .where(predicate)
+            .fetchOne();
+
+        return new PageImpl<>(recruitments, pageable, count == null ? 0 : count);
     }
 
     @Override

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -1,6 +1,5 @@
 package com.clova.anifriends.domain.recruitment.service;
 
-import com.clova.anifriends.domain.common.dto.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.response.FindCompletedRecruitmentsResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentDetailResponse;
@@ -73,8 +72,7 @@ public class RecruitmentService {
             pageable
         );
 
-        return FindRecruitmentsByShelterResponse.of(pagination.getContent(),
-            PageInfo.from(pagination));
+        return FindRecruitmentsByShelterResponse.from(pagination);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -286,14 +286,14 @@ class RecruitmentControllerTest extends BaseControllerTest {
                     fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부"),
                     fieldWithPath("recruitments[]").type(ARRAY).description("모집 게시글 리스트"),
                     fieldWithPath("recruitments[].recruitmentId").type(NUMBER).description("모집 ID"),
-                    fieldWithPath("recruitments[].title").type(STRING).description("모집 제목"),
-                    fieldWithPath("recruitments[].startTime").type(STRING).description("봉사 시작 시간"),
-                    fieldWithPath("recruitments[].endTime").type(STRING).description("봉사 끝난 시간"),
-                    fieldWithPath("recruitments[].deadline").type(STRING).description("모집 마감 시간"),
-                    fieldWithPath("recruitments[].isClosed").type(BOOLEAN).description("모집 마감 여부"),
-                    fieldWithPath("recruitments[].applicantCount").type(NUMBER)
+                    fieldWithPath("recruitments[].recruitmentTitle").type(STRING).description("모집 제목"),
+                    fieldWithPath("recruitments[].recruitmentStartTime").type(STRING).description("봉사 시작 시간"),
+                    fieldWithPath("recruitments[].recruitmentEndTime").type(STRING).description("봉사 끝난 시간"),
+                    fieldWithPath("recruitments[].recruitmentDeadline").type(STRING).description("모집 마감 시간"),
+                    fieldWithPath("recruitments[].recruitmentIsClosed").type(BOOLEAN).description("모집 마감 여부"),
+                    fieldWithPath("recruitments[].recruitmentApplicantCount").type(NUMBER)
                         .description("현재 지원자 수"),
-                    fieldWithPath("recruitments[].capacity").type(NUMBER).description("모집 정원")
+                    fieldWithPath("recruitments[].recruitmentCapacity").type(NUMBER).description("모집 정원")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentDtoFixture.java
@@ -1,6 +1,5 @@
 package com.clova.anifriends.domain.recruitment.support.fixture;
 
-import com.clova.anifriends.domain.common.dto.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentDetailResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterIdResponse;
@@ -11,7 +10,7 @@ public class RecruitmentDtoFixture {
 
     public static FindRecruitmentsByShelterResponse findRecruitmentsByShelterResponse(
         Page<Recruitment> pageResult) {
-        return FindRecruitmentsByShelterResponse.of(pageResult.getContent(), PageInfo.from(pageResult));
+        return FindRecruitmentsByShelterResponse.from(pageResult);
     }
 
     public static FindRecruitmentsByShelterIdResponse findRecruitmentsByShelterIdResponse(


### PR DESCRIPTION
### ⛏ 작업 사항
모집글 조회 & 검색(보호소)를 명세에 맞게 수정한다. 

### 📝 작업 요약
- responseDTO 변경
- 테스트 코드 수정
- 쿼리 함수에서 Page 객체에 직접 count 계산하여 넣기

### 💡 관련 이슈
- close #133 
