### PR TITLE
feat: 봉사 신청 현황 조회 로직을 구현한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
@@ -120,4 +120,8 @@ public class Applicant extends BaseTimeEntity {
     public void registerReview(Review review) {
         this.review = review;
     }
+
+    public boolean isCompleted() {
+        return this.status == ApplicantStatus.ATTENDANCE;
+    }
 }

--- a/src/main/java/com/clova/anifriends/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/controller/ApplicantController.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.applicant.controller;
 
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsApprovedResponse;
+import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.service.ApplicantService;
 import com.clova.anifriends.domain.auth.resolver.LoginUser;
@@ -42,5 +43,13 @@ public class ApplicantController {
         @PathVariable Long recruitmentId
     ) {
         return ResponseEntity.ok(applicantService.findApplicantsApproved(shelterId, recruitmentId));
+    }
+
+    @GetMapping("/shelters/recruitments/{recruitmentId}/applicants")
+    public ResponseEntity<FindApplicantsResponse> findApplicants(
+        @LoginUser Long shelterId,
+        @PathVariable Long recruitmentId
+    ) {
+        return ResponseEntity.ok(applicantService.findApplicants(shelterId, recruitmentId));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/applicant/dto/FindApplicantsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/dto/FindApplicantsResponse.java
@@ -1,0 +1,44 @@
+package com.clova.anifriends.domain.applicant.dto;
+
+import com.clova.anifriends.domain.applicant.Applicant;
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import java.time.LocalDate;
+import java.util.List;
+
+public record FindApplicantsResponse(
+    List<FindApplicantResponse> applicants,
+    Integer recruitmentCapacity
+) {
+
+    public record FindApplicantResponse(
+        Long volunteerId,
+        Long applicantId,
+        LocalDate volunteerBirthDate,
+        String volunteerGender,
+        Integer completedVolunteerCount,
+        Integer volunteerTemperature,
+        String applicantStatus
+    ) {
+
+        public static FindApplicantResponse from(Applicant applicant) {
+            return new FindApplicantResponse(
+                applicant.getVolunteer().getVolunteerId(),
+                applicant.getApplicantId(),
+                applicant.getVolunteer().getBirthDate(),
+                applicant.getVolunteer().getGender(),
+                applicant.getVolunteer().getApplicantCompletedCount(),
+                applicant.getVolunteer().getTemperature(),
+                applicant.getStatus().convertToApprovalStatus().name()
+            );
+        }
+    }
+
+    public static FindApplicantsResponse from(List<Applicant> applicants, Recruitment recruitment) {
+        return new FindApplicantsResponse(
+            applicants.stream()
+                .map(FindApplicantResponse::from)
+                .toList(),
+            recruitment.getCapacity()
+        );
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
@@ -3,8 +3,8 @@ package com.clova.anifriends.domain.applicant.repository;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.volunteer.Volunteer;
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,7 +23,7 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     )
     List<Applicant> findApplyingVolunteers(
         @Param("volunteer") Volunteer volunteer);
-    
+
     @Query("select a from Applicant a "
         + "where a.applicantId = :applicantId "
         + "and a.volunteer.volunteerId = :volunteerId")
@@ -39,6 +39,16 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
         + "and s.shelterId = :shelterId "
         + "and (a.status = 'ATTENDANCE' or a.status = 'NO_SHOW')")
     List<Applicant> findApprovedByRecruitmentIdAndShelterId(
+        @Param("recruitmentId") Long recruitmentId,
+        @Param("shelterId") Long shelterId
+    );
+
+    @Query("select a from Applicant a "
+        + "join fetch a.recruitment r "
+        + "join fetch r.shelter s "
+        + "where r.recruitmentId = :recruitmentId "
+        + "and s.shelterId = :shelterId ")
+    List<Applicant> findByRecruitmentIdAndShelterId(
         @Param("recruitmentId") Long recruitmentId,
         @Param("shelterId") Long shelterId
     );

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.applicant.service;
 
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsApprovedResponse;
+import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
@@ -60,8 +61,15 @@ public class ApplicantService {
 
     public FindApplicantsApprovedResponse findApplicantsApproved(Long shelterId,
         Long recruitmentId) {
-        List<Applicant> applicantApproved = applicantRepository
+        List<Applicant> applicantsApproved = applicantRepository
             .findApprovedByRecruitmentIdAndShelterId(recruitmentId, shelterId);
-        return FindApplicantsApprovedResponse.from(applicantApproved);
+        return FindApplicantsApprovedResponse.from(applicantsApproved);
+    }
+
+    public FindApplicantsResponse findApplicants(Long shelterId, Long recruitmentId) {
+        Recruitment recruitment = getRecruitment(recruitmentId);
+        List<Applicant> applicants = applicantRepository
+            .findByRecruitmentIdAndShelterId(recruitmentId, shelterId);
+        return FindApplicantsResponse.from(applicants, recruitment);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/applicant/wrapper/ApplicantStatus.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/wrapper/ApplicantStatus.java
@@ -8,10 +8,18 @@ public enum ApplicantStatus implements EnumType {
     REFUSED,
     ATTENDANCE,
     NO_SHOW,
+    APPROVED,
     ;
 
     @Override
     public String getName() {
         return this.name();
+    }
+
+    public ApplicantStatus convertToApprovalStatus() {
+        if (this == ApplicantStatus.ATTENDANCE || this == ApplicantStatus.NO_SHOW) {
+            return ApplicantStatus.APPROVED;
+        }
+        return this;
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
@@ -148,4 +148,10 @@ public class Volunteer extends BaseTimeEntity {
     public List<Applicant> getApplicants() {
         return Collections.unmodifiableList(applicants);
     }
+
+    public Integer getApplicantCompletedCount() {
+        return Math.toIntExact(applicants.stream()
+            .filter(Applicant::isCompleted)
+            .count());
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsApprovedResponse;
+import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.recruitment.Recruitment;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ApplicantControllerTest extends BaseControllerTest {
@@ -140,10 +142,10 @@ class ApplicantControllerTest extends BaseControllerTest {
     @DisplayName("봉사 신청 승인자 조회 API 호출 시")
     void findApplicantApproved() throws Exception {
         // given
-        FindApplicantsApprovedResponse.from(List.of());
+        FindApplicantsApprovedResponse response = FindApplicantsApprovedResponse.from(List.of());
 
         when(applicantService.findApplicantsApproved(anyLong(), anyLong()))
-            .thenReturn(FindApplicantsApprovedResponse.from(List.of()));
+            .thenReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(
@@ -177,4 +179,55 @@ class ApplicantControllerTest extends BaseControllerTest {
                 )
             );
     }
+
+    @Test
+    @DisplayName("봉사 신청자 리스트 조회 API 호출 시")
+    void findApplicant() throws Exception {
+        // given
+        Shelter shelter = ShelterFixture.shelter();
+        ReflectionTestUtils.setField(shelter, "shelterId", 1L);
+        Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+        ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
+
+        FindApplicantsResponse response = FindApplicantsResponse.from(List.of(), recruitment);
+        when(applicantService.findApplicants(anyLong(), anyLong())).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            get("/api/shelters/recruitments/{recruitmentId}/applicants",
+                recruitment.getRecruitmentId())
+                .header(AUTHORIZATION, shelterAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                    requestHeaders(
+                        headerWithName("Authorization").description("액세스 토큰")
+                    ),
+                    pathParameters(
+                        parameterWithName("recruitmentId").description("모집글 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("recruitmentCapacity").type(NUMBER).description("모집 정원"),
+                        fieldWithPath("applicants[]").type(ARRAY).description("봉사 신청자 리스트").optional(),
+                        fieldWithPath("applicants[].volunteerId").type(NUMBER).description("봉사자 ID"),
+                        fieldWithPath("applicants[].applicantId").type(NUMBER).description("봉사 신청 ID"),
+                        fieldWithPath("applicants[].volunteerName").type(NUMBER).description("봉사자 이름"),
+                        fieldWithPath("applicants[].volunteerBirthDate").type(STRING)
+                            .description("봉사자 생일"),
+                        fieldWithPath("applicants[].volunteerGender").type(STRING)
+                            .description("봉사자 성별"),
+                        fieldWithPath("applicants[].completedVolunteerCount").type(STRING)
+                            .description("봉사 횟수"),
+                        fieldWithPath("applicants[].volunteerTemperature").type(BOOLEAN)
+                            .description("봉사자 온도"),
+                        fieldWithPath("applicants[].applicantStatus").type(BOOLEAN)
+                            .description("신청 상태")
+                    )
+                )
+            );
+    }
+
 }

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -152,4 +152,41 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
                 false);
         }
     }
+
+    @Nested
+    @DisplayName("findByRecruitmentIdAndShelterId")
+    class FindRecruitmentIdAndShelterIdTest {
+
+        @Test
+        @DisplayName("성공")
+        void findByRecruitmentIdAndShelterId() {
+            // given
+            Shelter shelter = shelter();
+            Volunteer volunteer = volunteer();
+            Recruitment recruitment = recruitment(shelter);
+
+            Applicant applicantAttendance = applicant(recruitment, volunteer, ATTENDANCE);
+            Applicant applicantNoShow = applicant(recruitment, volunteer, NO_SHOW);
+            Applicant applicantPending = applicant(recruitment, volunteer, PENDING);
+            Applicant applicantRefused = applicant(recruitment, volunteer, REFUSED);
+
+            shelterRepository.save(shelter);
+            volunteerRepository.save(volunteer);
+            recruitmentRepository.save(recruitment);
+            applicantRepository.saveAll(
+                List.of(applicantAttendance, applicantNoShow, applicantPending, applicantRefused)
+            );
+            List<Applicant> expected = List.of(applicantAttendance, applicantNoShow,
+                applicantPending, applicantRefused);
+
+            // when
+            List<Applicant> result = applicantRepository
+                .findByRecruitmentIdAndShelterId(recruitment.getRecruitmentId(),
+                    shelter.getShelterId());
+
+            // then
+            assertThat(result).isEqualTo(expected);
+        }
+
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -2,7 +2,9 @@ package com.clova.anifriends.domain.applicant.service;
 
 import static com.clova.anifriends.domain.applicant.support.ApplicantFixture.applicant;
 import static com.clova.anifriends.domain.applicant.wrapper.ApplicantStatus.ATTENDANCE;
+import static com.clova.anifriends.domain.applicant.wrapper.ApplicantStatus.NO_SHOW;
 import static com.clova.anifriends.domain.applicant.wrapper.ApplicantStatus.PENDING;
+import static com.clova.anifriends.domain.applicant.wrapper.ApplicantStatus.REFUSED;
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture.recruitment;
 import static com.clova.anifriends.domain.shelter.support.ShelterFixture.shelter;
 import static com.clova.anifriends.domain.volunteer.support.VolunteerFixture.volunteer;
@@ -17,6 +19,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsApprovedResponse;
+import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
@@ -40,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicantServiceTest {
@@ -238,6 +242,45 @@ class ApplicantServiceTest {
                 .isWritedReview()).isEqualTo(
                 findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(1)
                     .isWritedReview());
+        }
+    }
+
+    @Nested
+    @DisplayName("findApplicants 메서드 실행 시")
+    class FindApplicantsTest {
+
+        @Test
+        @DisplayName("성공")
+        void findApplicants() {
+            // given
+            Shelter shelter = shelter();
+            ReflectionTestUtils.setField(shelter, "shelterId", 1L);
+            Recruitment recruitment = recruitment(shelter);
+            ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
+            Volunteer volunteer = volunteer();
+            Applicant applicantAttended = ApplicantFixture.applicant(recruitment, volunteer,
+                ATTENDANCE);
+            Applicant applicantRefused = ApplicantFixture.applicant(recruitment, volunteer,
+                REFUSED);
+            Applicant applicantPended = ApplicantFixture.applicant(recruitment, volunteer, PENDING);
+            Applicant applicantNoShow = ApplicantFixture.applicant(recruitment, volunteer, NO_SHOW);
+
+            FindApplicantsResponse response = FindApplicantsResponse.from(
+                List.of(applicantAttended, applicantRefused, applicantPended, applicantNoShow),
+                recruitment
+            );
+
+            when(recruitmentRepository.findById(anyLong())).thenReturn(Optional.of(recruitment));
+            when(applicantRepository.findByRecruitmentIdAndShelterId(anyLong(), anyLong()))
+                .thenReturn(
+                    List.of(applicantAttended, applicantRefused, applicantPended, applicantNoShow));
+
+            // when
+            FindApplicantsResponse result = applicantService.findApplicants(
+                shelter.getShelterId(), recruitment.getRecruitmentId());
+
+            // then
+            assertThat(result).isEqualTo(response);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
봉사 신청 현황 조회 로직을 구현했습니다.

### 📝 작업 요약
- 봉사 신청자 조회 레포지토리 구현
- 봉사 신청자 조회 레포지토리 테스트코드 작성
- 봉사 신청자 조회 서비스 구현
- 봉사 신청자 조회 서비스 테스트코드 작성
- 봉사 신청자 조회 컨트롤러 구현
- 봉사 신청자 조회 컨트롤러 테스트코드 작성

### 💡 관련 이슈
- close #68 
