### PR TITLE
refactor: 회원가입(봉사자) 로직에 패스워드 인코딩을 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
@@ -4,6 +4,7 @@ import static com.clova.anifriends.global.exception.ErrorCode.BAD_REQUEST;
 
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.common.BaseTimeEntity;
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
 import com.clova.anifriends.domain.volunteer.wrapper.VolunteerEmail;
 import com.clova.anifriends.domain.volunteer.wrapper.VolunteerGender;
@@ -76,10 +77,11 @@ public class Volunteer extends BaseTimeEntity {
         String birthDate,
         String phoneNumber,
         String gender,
-        String name
+        String name,
+        CustomPasswordEncoder passwordEncoder
     ) {
         this.email = new VolunteerEmail(email);
-        this.password = new VolunteerPassword(password);
+        this.password = new VolunteerPassword(password, passwordEncoder);
         this.birthDate = validateBirthDate(birthDate);
         this.phoneNumber = new VolunteerPhoneNumber(phoneNumber);
         this.gender = VolunteerGender.from(gender);

--- a/src/main/java/com/clova/anifriends/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/service/VolunteerService.java
@@ -1,5 +1,6 @@
 package com.clova.anifriends.domain.volunteer.service;
 
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class VolunteerService {
 
     private final VolunteerRepository volunteerRepository;
+    private final CustomPasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public CheckDuplicateVolunteerEmailResponse checkDuplicateVolunteerEmail(String email) {
@@ -32,8 +34,8 @@ public class VolunteerService {
         String phoneNumber,
         String gender
     ) {
-        Volunteer volunteer = new Volunteer(email, password, birthDate, phoneNumber, gender, name);
-
+        Volunteer volunteer = new Volunteer(email, password, birthDate, phoneNumber, gender, name,
+            passwordEncoder);
         volunteerRepository.save(volunteer);
         return volunteer.getVolunteerId();
     }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPassword.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPassword.java
@@ -1,13 +1,20 @@
 package com.clova.anifriends.domain.volunteer.wrapper;
 
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
+import com.clova.anifriends.domain.shelter.exception.ShelterBadRequestException;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
 import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.text.MessageFormat;
+import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VolunteerPassword {
 
     private static final int MIN_PASSWORD_LENGTH = 6;
@@ -16,18 +23,23 @@ public class VolunteerPassword {
     @Column(name = "password")
     private String password;
 
-    protected VolunteerPassword() {
+    public VolunteerPassword(String rawPassword, CustomPasswordEncoder passwordEncoder) {
+        validateNotNull(rawPassword);
+        validateVolunteerPasswordLength(rawPassword);
+        this.password = passwordEncoder.encodePassword(rawPassword);
     }
 
-    public VolunteerPassword(String value) {
-        validateVolunteerPassword(value);
-        this.password = value;
+    private void validateNotNull(String password) {
+        if (Objects.isNull(password)) {
+            throw new ShelterBadRequestException("패스워드는 필수값입니다.");
+        }
     }
 
-    private void validateVolunteerPassword(String password) {
+    private void validateVolunteerPasswordLength(String password) {
         if (password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
             throw new VolunteerBadRequestException(ErrorCode.BAD_REQUEST,
-                "비밀번호는 최소 6자, 최대 16자입니다.");
+                MessageFormat.format("패스워드는 {0}자 이상, {1}자 이하여야 합니다.",
+                    MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH));
         }
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPassword.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPassword.java
@@ -1,7 +1,6 @@
 package com.clova.anifriends.domain.volunteer.wrapper;
 
 import com.clova.anifriends.domain.common.CustomPasswordEncoder;
-import com.clova.anifriends.domain.shelter.exception.ShelterBadRequestException;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
 import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.persistence.Column;
@@ -31,7 +30,7 @@ public class VolunteerPassword {
 
     private void validateNotNull(String password) {
         if (Objects.isNull(password)) {
-            throw new ShelterBadRequestException("패스워드는 필수값입니다.");
+            throw new VolunteerBadRequestException(ErrorCode.BAD_REQUEST, "패스워드는 필수값입니다.");
         }
     }
 

--- a/src/test/java/com/clova/anifriends/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/auth/service/AuthServiceTest.java
@@ -63,8 +63,8 @@ class AuthServiceTest {
 
         String email = "email@email.com";
         String password = "password123!";
-        Volunteer volunteer = new Volunteer(email, passwordEncoder.encodePassword(password),
-            LocalDate.now().toString(), "010-1234-1234", "MALE", "name");
+        Volunteer volunteer = new Volunteer(email, password,
+            LocalDate.now().toString(), "010-1234-1234", "MALE", "name", passwordEncoder);
 
         @BeforeEach
         void setUp() {

--- a/src/test/java/com/clova/anifriends/domain/volunteer/VolunteerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/VolunteerTest.java
@@ -3,12 +3,22 @@ package com.clova.anifriends.domain.volunteer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.clova.anifriends.domain.auth.support.MockPasswordEncoder;
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class VolunteerTest {
+
+    CustomPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new MockPasswordEncoder();
+    }
 
     @Nested
     @DisplayName("Volunteer 생성 시")
@@ -21,6 +31,7 @@ class VolunteerTest {
         String gender = "MALE";
         String name = "홍길동";
 
+
         @Test
         @DisplayName("성공")
         void success() {
@@ -29,7 +40,7 @@ class VolunteerTest {
 
             // when
             Volunteer volunteer = new Volunteer(email, password, birthDate, phoneNumber, gender,
-                name);
+                name, passwordEncoder);
 
             // then
             assertThat(volunteer.getEmail()).isEqualTo(email);
@@ -44,7 +55,7 @@ class VolunteerTest {
             // when
             // then
             assertThatThrownBy(() -> new Volunteer(email, password, birthDate, phoneNumber, gender,
-                name))
+                name, passwordEncoder))
                 .isInstanceOf(VolunteerBadRequestException.class);
         }
     }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import com.clova.anifriends.domain.auth.support.MockPasswordEncoder;
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
 import com.clova.anifriends.domain.volunteer.dto.request.RegisterVolunteerRequest;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -35,6 +38,9 @@ class VolunteerServiceTest {
 
     @Mock
     VolunteerRepository volunteerRepository;
+
+    @Spy
+    CustomPasswordEncoder passwordEncoder = new MockPasswordEncoder();
 
     @Nested
     @DisplayName("checkDuplicateVolunteerEmail 메서드 실행 시")

--- a/src/test/java/com/clova/anifriends/domain/volunteer/support/VolunteerFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/support/VolunteerFixture.java
@@ -1,5 +1,7 @@
 package com.clova.anifriends.domain.volunteer.support;
 
+import com.clova.anifriends.domain.auth.support.MockPasswordEncoder;
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
 import com.clova.anifriends.domain.volunteer.wrapper.VolunteerGender;
@@ -15,9 +17,10 @@ public class VolunteerFixture {
     private static final Integer TEMPERATURE = 36;
     private static final String NAME = "김봉사";
     private static final String IMAGE_URL = "www.aws.s3.com/2";
+    private static final CustomPasswordEncoder PASSWORD_ENCODER = new MockPasswordEncoder();
 
     public static Volunteer volunteer() {
-        return new Volunteer(EMAIL, PASSWORD, BIRTH_DATE, PHONE_NUMBER, GENDER, NAME);
+        return new Volunteer(EMAIL, PASSWORD, BIRTH_DATE, PHONE_NUMBER, GENDER, NAME, PASSWORD_ENCODER);
     }
 
     public static VolunteerImage volunteerImage(Volunteer volunteer) {

--- a/src/test/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPasswordTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPasswordTest.java
@@ -2,7 +2,10 @@ package com.clova.anifriends.domain.volunteer.wrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchException;
 
+import com.clova.anifriends.domain.auth.support.MockPasswordEncoder;
+import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,6 +17,7 @@ class VolunteerPasswordTest {
     @DisplayName("VolunteerPassword 생성 시")
     class newVolunteerPasswordTest {
 
+        CustomPasswordEncoder passwordEncoder = new MockPasswordEncoder();
         String password;
 
         @Test
@@ -23,34 +27,48 @@ class VolunteerPasswordTest {
             password = "asdfqwer123";
 
             // when
-            VolunteerPassword volunteerPassword = new VolunteerPassword(password);
+            VolunteerPassword volunteerPassword = new VolunteerPassword(password, passwordEncoder);
 
             // then
-            assertThat(volunteerPassword.getPassword()).isEqualTo(password);
+            assertThat(passwordEncoder.matchesPassword(password, volunteerPassword.getPassword())).isTrue();
         }
 
         @Test
-        @DisplayName("예외: 비밀번호가 6자 미만인 경우")
+        @DisplayName("예외(VolunteerBadRequestException): 비밀번호가 6자 미만인 경우")
         void throwExceptionWhenPasswordIsLessThanSix() {
             // given
             password = "asdf";
 
             // when
             // then
-            assertThatThrownBy(() -> new VolunteerPassword(password))
+            assertThatThrownBy(() -> new VolunteerPassword(password, passwordEncoder))
                 .isInstanceOf(VolunteerBadRequestException.class);
         }
 
         @Test
-        @DisplayName("예외: 비밀번호가 16자 초과인 경우")
+        @DisplayName("예외(VolunteerBadRequestException): 비밀번호가 16자 초과인 경우")
         void throwExceptionWhenPasswordIsOverThanSixteen() {
             // given
             password = "asdfqwer123asdfqwer123";
 
             // when
             // then
-            assertThatThrownBy(() -> new VolunteerPassword(password))
+            assertThatThrownBy(() -> new VolunteerPassword(password, passwordEncoder))
                 .isInstanceOf(VolunteerBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("예외(VolunteerBadRequestException): 비밀번호가 null인 경우")
+        void throwExceptionWhenPasswordIsNull() {
+            // given
+            password = null;
+
+            // when
+            Exception exception = catchException(
+                () -> new VolunteerPassword(password, passwordEncoder));
+
+            // then
+            assertThat(exception).isInstanceOf(VolunteerBadRequestException.class);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자 회원가입 로직에 패스워드 인코딩 추가
- VolunteerPassword에서 passwordEncoder를 받아 rawPassword에 대한 validation을 마친 후 인코딩한 패스워드를 저장한다.
- service 단에서 passwordEncoder를 넘겨준다.

### 📝 작업 요약
- 봉사자 회원가입 로직에 패스워드 인코딩 추가
- 관련 테스트 코드 수정

### 💡 관련 이슈
- close #138 
