### PR TITLE
feat: 보호소가 받은 후기 리스트 조회(보호소) api 응답 필드를 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
@@ -15,6 +15,7 @@ public record FindShelterReviewsByShelterResponse(List<FindShelterReviewResponse
         LocalDateTime createdAt,
         String content,
         List<String> reviewImageUrls,
+        Long volunteerId,
 
         String volunteerName,
         int temperature,
@@ -28,6 +29,7 @@ public record FindShelterReviewsByShelterResponse(List<FindShelterReviewResponse
                 review.getCreatedAt(),
                 review.getContent(),
                 review.getImages(),
+                volunteer.getVolunteerId(),
                 volunteer.getName(),
                 volunteer.getTemperature(),
                 volunteer.getVolunteerImageUrl(),

--- a/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
@@ -109,6 +109,7 @@ class ReviewControllerTest extends BaseControllerTest {
         Volunteer volunteer = volunteer();
         Applicant applicant = applicant(recruitment, volunteer, ATTENDANCE);
         Review review = review(applicant);
+        ReflectionTestUtils.setField(volunteer, "volunteerId", 1L);
         ReflectionTestUtils.setField(review, "reviewId", 1L);
         ReflectionTestUtils.setField(review, "createdAt", LocalDateTime.now());
         PageImpl<Review> reviewPage = new PageImpl<>(List.of(review));
@@ -139,7 +140,8 @@ class ReviewControllerTest extends BaseControllerTest {
                     fieldWithPath("reviews[].createdAt").type(STRING).description("리뷰 생성일"),
                     fieldWithPath("reviews[].content").type(STRING).description("리뷰 내용"),
                     fieldWithPath("reviews[].reviewImageUrls").type(ARRAY)
-                        .description("리뷰 이미지 url 리스트").optional(),
+                    .description("리뷰 이미지 url 리스트").optional(),
+                    fieldWithPath("reviews[].volunteerId").type(NUMBER).description("봉사자 ID"),
                     fieldWithPath("reviews[].volunteerName").type(STRING).description("봉사자 이름"),
                     fieldWithPath("reviews[].temperature").type(NUMBER).description("봉사자 온도"),
                     fieldWithPath("reviews[].volunteerImageUrl").type(STRING)


### PR DESCRIPTION
### ⛏ 작업 사항
- 프론트엔드의 요청에 따라 보호소가 후기 리스트를 조회시 응답 필드에 volunteerId를 추가하였습니다.

### 📝 작업 요약
- 보호소가 받은 후기 리스트 조회(보호소) api 응답 필드 추가

### 💡 관련 이슈
- close #208 
