### PR TITLE
feat: 인증 객체 principal에 역할 필드를 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/auth/authentication/JwtAuthentication.java
+++ b/src/main/java/com/clova/anifriends/domain/auth/authentication/JwtAuthentication.java
@@ -1,5 +1,7 @@
 package com.clova.anifriends.domain.auth.authentication;
 
-public record JwtAuthentication(Long memberId, String accessToken) {
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+
+public record JwtAuthentication(Long userId, UserRole role, String accessToken) {
 
 }

--- a/src/main/java/com/clova/anifriends/domain/auth/authentication/JwtAuthenticationProvider.java
+++ b/src/main/java/com/clova/anifriends/domain/auth/authentication/JwtAuthenticationProvider.java
@@ -18,7 +18,7 @@ public class JwtAuthenticationProvider {
 
     public Authentication authenticate(String accessToken) {
         CustomClaims claims = jwtProvider.parseAccessToken(accessToken);
-        JwtAuthentication authentication = new JwtAuthentication(claims.memberId(), accessToken);
+        JwtAuthentication authentication = new JwtAuthentication(claims.memberId(), claims.role(), accessToken);
         List<GrantedAuthority> authorities = getAuthorities(claims.authorities());
         return UsernamePasswordAuthenticationToken.authenticated(authentication, accessToken,
             authorities);

--- a/src/main/java/com/clova/anifriends/domain/auth/dto/response/CustomClaims.java
+++ b/src/main/java/com/clova/anifriends/domain/auth/dto/response/CustomClaims.java
@@ -1,10 +1,11 @@
 package com.clova.anifriends.domain.auth.dto.response;
 
+import com.clova.anifriends.domain.auth.jwt.UserRole;
 import java.util.List;
 
-public record CustomClaims(Long memberId, List<String> authorities) {
+public record CustomClaims(Long memberId, UserRole role, List<String> authorities) {
 
-    public static CustomClaims of(Long memberId, List<String> authorities) {
-        return new CustomClaims(memberId, authorities);
+    public static CustomClaims of(Long memberId, UserRole role, List<String> authorities) {
+        return new CustomClaims(memberId, role, authorities);
     }
 }

--- a/src/main/java/com/clova/anifriends/global/security/jwt/JJwtProvider.java
+++ b/src/main/java/com/clova/anifriends/global/security/jwt/JJwtProvider.java
@@ -93,9 +93,9 @@ public class JJwtProvider implements JwtProvider {
         try {
             Claims claims = accessTokenParser.parseSignedClaims(token).getPayload();
             Long userId = Long.valueOf(claims.getSubject());
-            String userRole = claims.get(ROLE, String.class);
-            List<String> authorities = UserRole.valueOf(userRole).getAuthorities();
-            return CustomClaims.of(userId, authorities);
+            UserRole userRole = UserRole.valueOf(claims.get(ROLE, String.class));
+            List<String> authorities = userRole.getAuthorities();
+            return CustomClaims.of(userId, userRole, authorities);
         } catch (ExpiredJwtException ex) {
             log.info("[EX] {}: 만료된 JWT입니다.", ex.getClass().getSimpleName());
             throw new ExpiredAccessTokenException("만료된 액세스 토큰입니다.");

--- a/src/main/java/com/clova/anifriends/global/web/argumentresolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/clova/anifriends/global/web/argumentresolver/LoginUserArgumentResolver.java
@@ -29,7 +29,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         checkAuthenticated(authentication);
         JwtAuthentication jwtAuthentication = (JwtAuthentication) authentication.getPrincipal();
-        return jwtAuthentication.memberId();
+        return jwtAuthentication.userId();
     }
 
     private void checkAuthenticated(Authentication authentication) {

--- a/src/test/java/com/clova/anifriends/domain/auth/authentication/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/clova/anifriends/domain/auth/authentication/JwtAuthenticationProviderTest.java
@@ -23,10 +23,12 @@ class JwtAuthenticationProviderTest {
     class AuthenticateTest {
 
         @Test
-        @DisplayName("성공")
-        void authenticate() {
+        @DisplayName("성공: principal인 JwtAuthentication이 정상적으로 만들어짐")
+        void authenticateThenAuthenticationHasJwtAuthentication() {
             //given
-            TokenResponse tokenResponse = jwtProvider.createToken(1L, UserRole.ROLE_VOLUNTEER);
+            long userId = 1L;
+            UserRole userRole = UserRole.ROLE_VOLUNTEER;
+            TokenResponse tokenResponse = jwtProvider.createToken(userId, userRole);
 
             //when
             Authentication authentication = authenticationProvider.authenticate(
@@ -35,6 +37,23 @@ class JwtAuthenticationProviderTest {
             //then
             Object principal = authentication.getPrincipal();
             assertThat(principal.getClass()).isAssignableFrom(JwtAuthentication.class);
+            JwtAuthentication jwtAuthentication = (JwtAuthentication) principal;
+            assertThat(jwtAuthentication.userId()).isEqualTo(userId);
+            assertThat(jwtAuthentication.role()).isEqualTo(userRole);
+            assertThat(jwtAuthentication.accessToken()).isEqualTo(tokenResponse.accessToken());
+        }
+
+        @Test
+        @DisplayName("성공: 인증 객체인 UsernamePasswordAuthenticationToken이 정상적으로 만들어짐")
+        void authenticateThenUsernamePasswordAuthenticationTokenIsPublish() {
+            //given
+            TokenResponse tokenResponse = jwtProvider.createToken(1L, UserRole.ROLE_VOLUNTEER);
+
+            //when
+            Authentication authentication = authenticationProvider.authenticate(
+                tokenResponse.accessToken());
+
+            //then
             UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken
                 = (UsernamePasswordAuthenticationToken) authentication;
             assertThat(usernamePasswordAuthenticationToken.getAuthorities())

--- a/src/test/java/com/clova/anifriends/domain/auth/resolver/LoginUserArgumentResolverTest.java
+++ b/src/test/java/com/clova/anifriends/domain/auth/resolver/LoginUserArgumentResolverTest.java
@@ -65,4 +65,22 @@ class LoginUserArgumentResolverTest extends BaseControllerTest {
                 .andExpect(jsonPath("$").doesNotExist());
         }
     }
+
+    @Nested
+    @DisplayName("@AuthenticationPrincipal을 사용하는 경우")
+    class AuthenticationPrincipalTest {
+
+        @Test
+        @DisplayName("성공")
+        void authenticationPrincipal() throws Exception {
+            //given
+
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/test/authentication-principal")
+                .header(AUTHORIZATION, shelterAccessToken));
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/auth/resolver/LoginUserTestController.java
+++ b/src/test/java/com/clova/anifriends/domain/auth/resolver/LoginUserTestController.java
@@ -1,7 +1,9 @@
 package com.clova.anifriends.domain.auth.resolver;
 
 import com.clova.anifriends.domain.auth.LoginUser;
+import com.clova.anifriends.domain.auth.authentication.JwtAuthentication;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,5 +20,11 @@ public class LoginUserTestController {
     @GetMapping("/login-user/invalid")
     public ResponseEntity<String> invalidLoginUser(@LoginUser String memberId) {
         return ResponseEntity.ok(memberId);
+    }
+
+    @GetMapping("/authentication-principal")
+    public ResponseEntity<JwtAuthentication> jwtAuthentication(
+        @AuthenticationPrincipal JwtAuthentication jwtAuthentication) {
+        return ResponseEntity.ok(jwtAuthentication);
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 인증 객체의 principal인 JwtAuthentication에 사용자 역할 필드를 추가하였습니다.
- 사용자의 역할에 대한 정보가 필요한 경우 컨트롤러의 시그니처에 JwtAuthentication 타입의 파라미터를 추가해주시고 스프링 시큐리티가 제공하는 `@AuthenticationPrincipal`을 파라미터 앞에 명시해주시면 됩니다.

### 📝 작업 요약
- JwtAuthentication에 사용자 역할 필드 추가

### 💡 관련 이슈
- close #224 
