### PR TITLE
feat: 보호소 새로운 알림 여부 조회 API를 구현한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationController.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationController.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.notification.controller;
 
 import com.clova.anifriends.domain.auth.LoginUser;
+import com.clova.anifriends.domain.notification.dto.response.FindShelterHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindShelterNotificationsResponse;
 import com.clova.anifriends.domain.notification.service.ShelterNotificationService;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,13 @@ public class ShelterNotificationController {
         @LoginUser Long shelterId
     ) {
         return ResponseEntity.ok(shelterNotificationService.findShelterNotifications(shelterId));
+    }
+
+    @GetMapping("/shelters/notifications/read")
+    public ResponseEntity<FindShelterHasNewNotificationResponse> findShelterHasNewNotification(
+        @LoginUser Long shelterId
+    ) {
+        return ResponseEntity.ok(
+            shelterNotificationService.findShelterHasNewNotification(shelterId));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/notification/dto/response/FindShelterHasNewNotificationResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/dto/response/FindShelterHasNewNotificationResponse.java
@@ -1,0 +1,10 @@
+package com.clova.anifriends.domain.notification.dto.response;
+
+public record FindShelterHasNewNotificationResponse (
+    boolean hasNewNotification
+) {
+
+    public static FindShelterHasNewNotificationResponse from (boolean hasNewNotification) {
+        return new FindShelterHasNewNotificationResponse(hasNewNotification);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepository.java
@@ -3,8 +3,13 @@ package com.clova.anifriends.domain.notification.repository;
 import com.clova.anifriends.domain.notification.ShelterNotification;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ShelterNotificationRepository extends JpaRepository<ShelterNotification, Long> {
 
     List<ShelterNotification> findByShelter_ShelterIdOrderByCreatedAtDesc(Long shelterId);
+
+    @Query("select exists (select s from ShelterNotification s where s.shelter.shelterId = :shelterId and s.isRead.isRead = false)")
+    boolean hasNewNotification(@Param("shelterId") Long shelterId);
 }

--- a/src/main/java/com/clova/anifriends/domain/notification/service/ShelterNotificationService.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/service/ShelterNotificationService.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.notification.service;
 
 import com.clova.anifriends.domain.notification.ShelterNotification;
+import com.clova.anifriends.domain.notification.dto.response.FindShelterHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindShelterNotificationsResponse;
 import com.clova.anifriends.domain.notification.repository.ShelterNotificationRepository;
 import java.util.List;
@@ -19,5 +20,11 @@ public class ShelterNotificationService {
         List<ShelterNotification> shelterNotifications = shelterNotificationRepository.findByShelter_ShelterIdOrderByCreatedAtDesc(
             shelterId);
         return FindShelterNotificationsResponse.from(shelterNotifications);
+    }
+
+    @Transactional(readOnly = true)
+    public FindShelterHasNewNotificationResponse findShelterHasNewNotification(Long shelterId) {
+        return FindShelterHasNewNotificationResponse.from(
+            shelterNotificationRepository.hasNewNotification(shelterId));
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.domain.notification.ShelterNotification;
+import com.clova.anifriends.domain.notification.dto.response.FindShelterHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindShelterNotificationsResponse;
 import com.clova.anifriends.domain.notification.support.fixture.ShelterNotificationFixture;
 import com.clova.anifriends.domain.shelter.Shelter;
@@ -65,6 +66,33 @@ class ShelterNotificationControllerTest extends BaseControllerTest {
                         .description("알림 읽음 여부"),
                     fieldWithPath("notifications[].notificationType").type(STRING)
                         .description("알림 타입")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공")
+    void findShelterHasNewNotification() throws Exception {
+        // given
+        FindShelterHasNewNotificationResponse findShelterHasNewNotificationResponse = FindShelterHasNewNotificationResponse.from(
+            true);
+        given(shelterNotificationService.findShelterHasNewNotification(anyLong()))
+            .willReturn(findShelterHasNewNotificationResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/shelters/notifications/read")
+            .header(AUTHORIZATION, shelterAccessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION).description("보호소 액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("hasNewNotification").type(BOOLEAN).description("새로운 알림 존재 여부")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.clova.anifriends.base.BaseRepositoryTest;
 import com.clova.anifriends.domain.notification.ShelterNotification;
 import com.clova.anifriends.domain.notification.support.fixture.ShelterNotificationFixture;
+import com.clova.anifriends.domain.notification.wrapper.NotificationRead;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import java.time.LocalDateTime;
@@ -41,6 +42,54 @@ class ShelterNotificationRepositoryTest extends BaseRepositoryTest {
             // then
             assertThat(expected.get(0)).isEqualTo(notification2);
             assertThat(expected.get(1)).isEqualTo(notification1);
+        }
+    }
+
+    @Nested
+    @DisplayName("hasNewNotification 실행 시")
+    class HasNewNotificationTest {
+
+        @Test
+        @DisplayName("성공: 안 읽은 알림이 없는 경우")
+        void hasNewNotificationFalse() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(shelter);
+            NotificationRead notificationRead = new NotificationRead(true);
+            ReflectionTestUtils.setField(notification1, "isRead", notificationRead);
+            ReflectionTestUtils.setField(notification2, "isRead", notificationRead);
+
+            shelterRepository.save(shelter);
+            shelterNotificationRepository.save(notification1);
+            shelterNotificationRepository.save(notification2);
+
+            // when
+            boolean expected = shelterNotificationRepository.hasNewNotification(shelter.getShelterId());
+
+            // then
+            assertThat(expected).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 안 읽은 알림이 있는 경우")
+        void hasNewNotificationTrue() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(shelter);
+            NotificationRead notificationRead = new NotificationRead(true);
+            ReflectionTestUtils.setField(notification1, "isRead", notificationRead);
+
+            shelterRepository.save(shelter);
+            shelterNotificationRepository.save(notification1);
+            shelterNotificationRepository.save(notification2);
+
+            // when
+            boolean expected = shelterNotificationRepository.hasNewNotification(shelter.getShelterId());
+
+            // then
+            assertThat(expected).isTrue();
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/service/ShelterNotificationServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/service/ShelterNotificationServiceTest.java
@@ -1,16 +1,17 @@
 package com.clova.anifriends.domain.notification.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.clova.anifriends.domain.notification.ShelterNotification;
+import com.clova.anifriends.domain.notification.dto.response.FindShelterHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindShelterNotificationsResponse;
 import com.clova.anifriends.domain.notification.repository.ShelterNotificationRepository;
 import com.clova.anifriends.domain.notification.support.fixture.ShelterNotificationFixture;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,26 @@ class ShelterNotificationServiceTest {
             FindShelterNotificationsResponse result = shelterNotificationService.findShelterNotifications(shelter.getShelterId());
 
             // then
-            Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("findShelterHasNewNotification 메서드 실행 시")
+    class FindShelterHasNewNotificationTest {
+
+        @Test
+        @DisplayName("성공")
+        void findShelterHasNewNotification() {
+            // given
+            FindShelterHasNewNotificationResponse expected = FindShelterHasNewNotificationResponse.from(true);
+            given(shelterNotificationRepository.hasNewNotification(anyLong())).willReturn(true);
+
+            // when
+            FindShelterHasNewNotificationResponse result = shelterNotificationService.findShelterHasNewNotification(1L);
+
+            // then
+            assertThat(result).isEqualTo(expected);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
보호소 새로운 알림 여부 조회 API 구현

### 📝 작업 요약
- 보호소 새로운 알림 존재 여부 조회를 위해 쿼리, 컨트롤러단 메서드, 서비스단 메서드 작성
- 테스트 코드 작성

### 💡 관련 이슈
- close #198 
