### PR TITLE
feat: 봉사자 새로운 알림 여부 조회 API를 구현한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationController.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationController.java
@@ -2,7 +2,7 @@ package com.clova.anifriends.domain.notification.controller;
 
 
 import com.clova.anifriends.domain.auth.LoginUser;
-import com.clova.anifriends.domain.notification.dto.FindVolunteerNotificationsResponse;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.service.VolunteerNotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationController.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationController.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.notification.controller;
 
 
 import com.clova.anifriends.domain.auth.LoginUser;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.service.VolunteerNotificationService;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,13 @@ public class VolunteerNotificationController {
     ) {
         return ResponseEntity.ok(
             volunteerNotificationService.findVolunteerNotifications(volunteerId));
+    }
+
+    @GetMapping("/volunteers/notifications/read")
+    public ResponseEntity<FindVolunteerHasNewNotificationResponse> findVolunteerHasNewNotification(
+        @LoginUser Long volunteerId
+    ) {
+        return ResponseEntity.ok(
+            volunteerNotificationService.findVolunteerHasNewNotification(volunteerId));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/notification/dto/response/FindVolunteerHasNewNotificationResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/dto/response/FindVolunteerHasNewNotificationResponse.java
@@ -1,0 +1,10 @@
+package com.clova.anifriends.domain.notification.dto.response;
+
+public record FindVolunteerHasNewNotificationResponse (
+    boolean hasNewNotification
+) {
+
+    public static FindVolunteerHasNewNotificationResponse from (boolean hasNewNotification) {
+        return new FindVolunteerHasNewNotificationResponse(hasNewNotification);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/notification/dto/response/FindVolunteerNotificationsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/dto/response/FindVolunteerNotificationsResponse.java
@@ -1,4 +1,4 @@
-package com.clova.anifriends.domain.notification.dto;
+package com.clova.anifriends.domain.notification.dto.response;
 
 import com.clova.anifriends.domain.notification.VolunteerNotification;
 import com.clova.anifriends.domain.notification.wrapper.NotificationType;

--- a/src/main/java/com/clova/anifriends/domain/notification/repository/VolunteerNotificationRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/repository/VolunteerNotificationRepository.java
@@ -3,8 +3,13 @@ package com.clova.anifriends.domain.notification.repository;
 import com.clova.anifriends.domain.notification.VolunteerNotification;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VolunteerNotificationRepository extends JpaRepository<VolunteerNotification, Long> {
 
     List<VolunteerNotification> findByVolunteer_VolunteerIdOrderByCreatedAtDesc(Long volunteerId);
+
+    @Query("select exists (select v from VolunteerNotification v where v.volunteer.volunteerId = :volunteerId and v.isRead.isRead = false)")
+    boolean hasNewNotification(@Param("volunteerId") Long volunteerId);
 }

--- a/src/main/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationService.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationService.java
@@ -1,7 +1,7 @@
 package com.clova.anifriends.domain.notification.service;
 
 import com.clova.anifriends.domain.notification.VolunteerNotification;
-import com.clova.anifriends.domain.notification.dto.FindVolunteerNotificationsResponse;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.repository.VolunteerNotificationRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationService.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationService.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.notification.service;
 
 import com.clova.anifriends.domain.notification.VolunteerNotification;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.repository.VolunteerNotificationRepository;
 import java.util.List;
@@ -19,5 +20,11 @@ public class VolunteerNotificationService {
         List<VolunteerNotification> volunteerNotifications = volunteerNotificationRepository.findByVolunteer_VolunteerIdOrderByCreatedAtDesc(
             volunteerId);
         return FindVolunteerNotificationsResponse.from(volunteerNotifications);
+    }
+
+    @Transactional(readOnly = true)
+    public FindVolunteerHasNewNotificationResponse findVolunteerHasNewNotification(Long volunteerId) {
+        return FindVolunteerHasNewNotificationResponse.from(
+            volunteerNotificationRepository.hasNewNotification(volunteerId));
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationControllerTest.java
@@ -71,7 +71,7 @@ class ShelterNotificationControllerTest extends BaseControllerTest {
     }
 
     @Test
-    @DisplayName("성공")
+    @DisplayName("성공: 보호소 새로운 알림 여부 조회 api 호출 시")
     void findShelterHasNewNotification() throws Exception {
         // given
         FindShelterHasNewNotificationResponse findShelterHasNewNotificationResponse = FindShelterHasNewNotificationResponse.from(

--- a/src/test/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.domain.notification.VolunteerNotification;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.support.fixture.VolunteerNotificationFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
@@ -23,6 +24,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -65,6 +67,33 @@ class VolunteerNotificationControllerTest extends BaseControllerTest {
                         .description("알림 읽음 여부"),
                     fieldWithPath("notifications[].notificationType").type(STRING)
                         .description("알림 타입")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 봉사자 새로운 알림 여부 조회 api 호출 시")
+    void findVolunteerHasNewNotification() throws Exception {
+        // given
+        FindVolunteerHasNewNotificationResponse findVolunteerHasNewNotificationResponse = FindVolunteerHasNewNotificationResponse.from(
+            true);
+        given(volunteerNotificationService.findVolunteerHasNewNotification(anyLong()))
+            .willReturn(findVolunteerHasNewNotificationResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/volunteers/notifications/read")
+            .header(AUTHORIZATION, volunteerAccessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION).description("봉사자 액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("hasNewNotification").type(JsonFieldType.BOOLEAN).description("새로운 알림 존재 여부")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/controller/VolunteerNotificationControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.clova.anifriends.base.BaseControllerTest;
 import com.clova.anifriends.domain.notification.VolunteerNotification;
-import com.clova.anifriends.domain.notification.dto.FindVolunteerNotificationsResponse;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.support.fixture.VolunteerNotificationFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;

--- a/src/test/java/com/clova/anifriends/domain/notification/repository/VolunteerNotificationRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/repository/VolunteerNotificationRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.clova.anifriends.base.BaseRepositoryTest;
 import com.clova.anifriends.domain.notification.VolunteerNotification;
 import com.clova.anifriends.domain.notification.support.fixture.VolunteerNotificationFixture;
+import com.clova.anifriends.domain.notification.wrapper.NotificationRead;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import java.time.LocalDateTime;
@@ -41,6 +42,54 @@ class VolunteerNotificationRepositoryTest extends BaseRepositoryTest {
             // then
             assertThat(expected.get(0)).isEqualTo(notification2);
             assertThat(expected.get(1)).isEqualTo(notification1);
+        }
+    }
+
+    @Nested
+    @DisplayName("hasNewNotification 실행 시")
+    class HasNewNotificationTest {
+
+        @Test
+        @DisplayName("성공: 안 읽은 알림이 없는 경우")
+        void hasNewNotificationFalse() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            VolunteerNotification notification1 = VolunteerNotificationFixture.volunteerNotification(volunteer);
+            VolunteerNotification notification2 = VolunteerNotificationFixture.volunteerNotification(volunteer);
+            NotificationRead notificationRead = new NotificationRead(true);
+            ReflectionTestUtils.setField(notification1, "isRead", notificationRead);
+            ReflectionTestUtils.setField(notification2, "isRead", notificationRead);
+
+            volunteerRepository.save(volunteer);
+            volunteerNotificationRepository.save(notification1);
+            volunteerNotificationRepository.save(notification2);
+
+            // when
+            boolean expected = volunteerNotificationRepository.hasNewNotification(volunteer.getVolunteerId());
+
+            // then
+            assertThat(expected).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 안 읽은 알림이 있는 경우")
+        void hasNewNotificationTrue() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            VolunteerNotification notification1 = VolunteerNotificationFixture.volunteerNotification(volunteer);
+            VolunteerNotification notification2 = VolunteerNotificationFixture.volunteerNotification(volunteer);
+            NotificationRead notificationRead = new NotificationRead(true);
+            ReflectionTestUtils.setField(notification2, "isRead", notificationRead);
+
+            volunteerRepository.save(volunteer);
+            volunteerNotificationRepository.save(notification1);
+            volunteerNotificationRepository.save(notification2);
+
+            // when
+            boolean expected = volunteerNotificationRepository.hasNewNotification(volunteer.getVolunteerId());
+
+            // then
+            assertThat(expected).isTrue();
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.clova.anifriends.domain.notification.VolunteerNotification;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerHasNewNotificationResponse;
 import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.repository.VolunteerNotificationRepository;
 import com.clova.anifriends.domain.notification.support.fixture.VolunteerNotificationFixture;
@@ -53,6 +54,26 @@ class VolunteerNotificationServiceTest {
 
             // then
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("findVolunteerHasNewNotification 메서드 실행 시")
+    class FindVolunteerHasNewNotificationTest {
+
+        @Test
+        @DisplayName("성공")
+        void findVolunteerHasNewNotification() {
+            // given
+            FindVolunteerHasNewNotificationResponse expected = FindVolunteerHasNewNotificationResponse.from(true);
+            given(volunteerNotificationRepository.hasNewNotification(anyLong())).willReturn(true);
+
+            // when
+            FindVolunteerHasNewNotificationResponse result = volunteerNotificationService.findVolunteerHasNewNotification(
+                1L);
+
+            // then
+            assertThat(result).isEqualTo(expected);
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationServiceTest.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.clova.anifriends.domain.notification.VolunteerNotification;
-import com.clova.anifriends.domain.notification.dto.FindVolunteerNotificationsResponse;
+import com.clova.anifriends.domain.notification.dto.response.FindVolunteerNotificationsResponse;
 import com.clova.anifriends.domain.notification.repository.VolunteerNotificationRepository;
 import com.clova.anifriends.domain.notification.support.fixture.VolunteerNotificationFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;


### PR DESCRIPTION
### ⛏ 작업 사항
봉사자 새로운 알림 여부 조회 API 구현

### 📝 작업 요약
- 봉사자 새로운 알림 존재 여부 조회를 위해 쿼리, 컨트롤러단 메서드, 서비스단 메서드 작성
- 테스트 코드 작성

### 💡 관련 이슈
- close #231 
