### PR TITLE
feat: 새로운 채팅방에서 메시지 발생 시 메시지를 publish 한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/chat/ChatMessage.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/ChatMessage.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.chat;
 
 import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.chat.exception.ChatMessageBadRequestException;
 import com.clova.anifriends.domain.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,6 +11,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.text.MessageFormat;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage extends BaseTimeEntity {
 
+    public static final int MAX_MESSAGE_LENGTH = 1000;
     @Id
     @Column(name = "chat_message_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,10 +46,44 @@ public class ChatMessage extends BaseTimeEntity {
     private boolean isRead;
 
     public ChatMessage(ChatRoom chatRoom, Long senderId, UserRole senderRole, String message) {
+        validateChatRoom(chatRoom);
+        validateSenderId(senderId);
+        validateSenderRole(senderRole);
+        validateMessage(message);
+
         this.chatRoom = chatRoom;
         this.senderId = senderId;
         this.senderRole = senderRole;
         this.message = message;
         this.isRead = false;
+    }
+
+    private void validateMessage(String message) {
+        if (Objects.isNull(message) || message.isBlank()) {
+            throw new ChatMessageBadRequestException("메시지가 존재하지 않습니다.");
+        }
+        if (message.length() > MAX_MESSAGE_LENGTH) {
+            throw new ChatMessageBadRequestException(
+                MessageFormat.format("메시지는 {0}자 이하로 입력해주세요.", MAX_MESSAGE_LENGTH)
+            );
+        }
+    }
+
+    private void validateSenderRole(UserRole senderRole) {
+        if (Objects.isNull(senderRole)) {
+            throw new ChatMessageBadRequestException("메시지 전송자의 타입이 존재하지 않습니다.");
+        }
+    }
+
+    private void validateSenderId(Long senderId) {
+        if (Objects.isNull(senderId)) {
+            throw new ChatMessageBadRequestException("메시지 전송자의 아이디가 존재하지 않습니다.");
+        }
+    }
+
+    private void validateChatRoom(ChatRoom chatRoom) {
+        if (Objects.isNull(chatRoom)) {
+            throw new ChatMessageBadRequestException("채팅방이 존재하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/controller/ChatMessageController.java
@@ -1,13 +1,30 @@
 package com.clova.anifriends.domain.chat.controller;
 
+import com.clova.anifriends.domain.chat.message.pub.NewChatMessagePub;
+import com.clova.anifriends.domain.chat.message.sub.ChatMessageSub;
+import com.clova.anifriends.domain.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
 public class ChatMessageController {
 
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final ChatMessageService chatMessageService;
+
+    @MessageMapping("/new/chat/rooms/{chatRoomId}/shelters/{shelterId}")
+    @SendTo("/sub/new/chat/rooms/shelters/{shelterId}")
+    public NewChatMessagePub newChatMessage(
+        @DestinationVariable Long chatRoomId,
+        @Payload ChatMessageSub chatMessageSub
+    ) {
+        return chatMessageService.registerChatMessage(
+            chatRoomId, chatMessageSub.chatSenderId(), chatMessageSub.chatSenderRole(),
+            chatMessageSub.chatMessage());
+    }
 
 }

--- a/src/main/java/com/clova/anifriends/domain/chat/exception/ChatMessageBadRequestException.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/exception/ChatMessageBadRequestException.java
@@ -1,0 +1,12 @@
+package com.clova.anifriends.domain.chat.exception;
+
+import static com.clova.anifriends.global.exception.ErrorCode.BAD_REQUEST;
+
+import com.clova.anifriends.global.exception.BadRequestException;
+
+public class ChatMessageBadRequestException extends BadRequestException {
+
+    public ChatMessageBadRequestException(String message) {
+        super(BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/chat/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,12 @@
+package com.clova.anifriends.domain.chat.exception;
+
+import static com.clova.anifriends.global.exception.ErrorCode.NOT_FOUND;
+
+import com.clova.anifriends.global.exception.NotFoundException;
+
+public class ChatRoomNotFoundException extends NotFoundException {
+
+    public ChatRoomNotFoundException(String message) {
+        super(NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/chat/message/pub/NewChatMessagePub.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/message/pub/NewChatMessagePub.java
@@ -1,0 +1,32 @@
+package com.clova.anifriends.domain.chat.message.pub;
+
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.chat.ChatMessage;
+import java.time.LocalDateTime;
+
+public record NewChatMessagePub(
+    Long chatRoomId,
+    NewChatMessage chatMessage
+) {
+
+    public static NewChatMessagePub from(ChatMessage chatMessage) {
+        return new NewChatMessagePub(
+            chatMessage.getChatRoom().getChatRoomId(),
+            new NewChatMessage(
+                chatMessage.getSenderId(),
+                chatMessage.getSenderRole(),
+                chatMessage.getMessage(),
+                chatMessage.getCreatedAt()
+            )
+        );
+    }
+
+    public record NewChatMessage(
+        Long chatSenderId,
+        UserRole chatSenderRole,
+        String chatMessage,
+        LocalDateTime createdAt
+    ) {
+
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/chat/message/sub/ChatMessageSub.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/message/sub/ChatMessageSub.java
@@ -1,0 +1,11 @@
+package com.clova.anifriends.domain.chat.message.sub;
+
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+
+public record ChatMessageSub(
+    Long chatSenderId,
+    UserRole chatSenderRole,
+    String chatMessage
+) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,37 @@
+package com.clova.anifriends.domain.chat.service;
+
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.chat.ChatMessage;
+import com.clova.anifriends.domain.chat.ChatRoom;
+import com.clova.anifriends.domain.chat.exception.ChatRoomNotFoundException;
+import com.clova.anifriends.domain.chat.message.pub.NewChatMessagePub;
+import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
+import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    public NewChatMessagePub registerChatMessage(
+        Long chatRoomId,
+        Long senderId,
+        UserRole senderRole,
+        String message
+    ) {
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
+        ChatMessage chatMessage = new ChatMessage(chatRoom, senderId, senderRole, message);
+        chatMessageRepository.save(chatMessage);
+
+        return NewChatMessagePub.from(chatMessage);
+    }
+
+    private ChatRoom getChatRoom(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+            .orElseThrow(() -> new ChatRoomNotFoundException("존재하지 않는 채팅방입니다."));
+    }
+}

--- a/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
@@ -15,6 +15,7 @@ import com.clova.anifriends.domain.auth.authentication.JwtAuthenticationProvider
 import com.clova.anifriends.domain.auth.jwt.JwtProvider;
 import com.clova.anifriends.domain.auth.service.AuthService;
 import com.clova.anifriends.domain.auth.support.AuthFixture;
+import com.clova.anifriends.domain.chat.service.ChatMessageService;
 import com.clova.anifriends.domain.chat.service.ChatRoomService;
 import com.clova.anifriends.domain.notification.service.ShelterNotificationService;
 import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
@@ -109,6 +110,9 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected ChatRoomService chatRoomService;
+
+    @MockBean
+    protected ChatMessageService chatMessageService;
 
     @MockBean
     protected SimpMessageSendingOperations messagingTemplate;

--- a/src/test/java/com/clova/anifriends/domain/chat/ChatMessageTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/ChatMessageTest.java
@@ -1,0 +1,176 @@
+package com.clova.anifriends.domain.chat;
+
+import static com.clova.anifriends.domain.auth.jwt.UserRole.ROLE_VOLUNTEER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.chat.exception.ChatMessageBadRequestException;
+import com.clova.anifriends.domain.chat.support.ChatRoomFixture;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ChatMessageTest {
+
+    @Nested
+    @DisplayName("ChatMessage 생성 시")
+    class NewChatMessageTest {
+
+        @Test
+        @DisplayName("성공: 메시지가 1자인 경우")
+        void newChatMessage1() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long senderId = 1L;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String message = "악";
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, senderId, senderRole, message));
+
+            // then
+            assertThat(exception).isNull();
+        }
+
+        @Test
+        @DisplayName("성공: 메시지가 1000자인 경우")
+        void newChatMessage2() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long senderId = 1L;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String message = "악".repeat(1000);
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, senderId, senderRole, message));
+
+            // then
+            assertThat(exception).isNull();
+        }
+
+        @Test
+        @DisplayName("예외(ChatMessageBadRequestException): 채팅방이 존재하지 않을 경우")
+        void exceptionWhenChatRoomIsNull() {
+            // given
+            ChatRoom nullChatRoom = null;
+            Long senderId = 1L;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String message = "안녕하세요";
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(nullChatRoom, senderId, senderRole, message));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatMessageBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("예외(ChatMessageBadRequestException): 전송자 타입이 존재하지 않을 경우")
+        void exceptionWhenSenderTypeIsNull() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long senderId = 1L;
+            UserRole nullSenderRole = null;
+            String message = "안녕하세요";
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, senderId, nullSenderRole, message));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatMessageBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("예외(ChatMessageBadRequestException): 전송자 ID가 존재하지 않을 경우")
+        void exceptionWhenSenderIDIsNull() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long nullSenderId = null;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String message = "안녕하세요";
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, nullSenderId, senderRole, message));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatMessageBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("예외(ChatMessageBadRequestException): 메시지가 null인 경우")
+        void exceptionWhenMessageIsNull() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long senderId = 1L;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String nullMessage = null;
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, senderId, senderRole, nullMessage));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatMessageBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("예외(ChatMessageBadRequestException): 메시지가 비어있는 경우")
+        void exceptionWhenMessageIsBlank() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long senderId = 1L;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String blankMessage = "";
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, senderId, senderRole, blankMessage));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatMessageBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("예외(ChatMessageBadRequestException): 메시지가 1000자 넘는 경우")
+        void exceptionWhenMessageIsOver1000() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            Long senderId = 1L;
+            UserRole senderRole = ROLE_VOLUNTEER;
+            String overMessage = "악".repeat(1001);
+
+            // when
+            Exception exception = catchException(
+                () -> new ChatMessage(chatRoom, senderId, senderRole, overMessage));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatMessageBadRequestException.class);
+        }
+
+    }
+
+}

--- a/src/test/java/com/clova/anifriends/domain/chat/ChatMessageTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/ChatMessageTest.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.chat;
 import static com.clova.anifriends.domain.auth.jwt.UserRole.ROLE_VOLUNTEER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.clova.anifriends.domain.auth.jwt.UserRole;
 import com.clova.anifriends.domain.chat.exception.ChatMessageBadRequestException;
@@ -33,11 +34,15 @@ class ChatMessageTest {
             String message = "악";
 
             // when
-            Exception exception = catchException(
-                () -> new ChatMessage(chatRoom, senderId, senderRole, message));
+            ChatMessage result = new ChatMessage(chatRoom, senderId, senderRole, message);
 
             // then
-            assertThat(exception).isNull();
+            assertSoftly(softAssertion -> {
+                softAssertion.assertThat(result.getChatRoom()).isEqualTo(chatRoom);
+                softAssertion.assertThat(result.getSenderId()).isEqualTo(senderId);
+                softAssertion.assertThat(result.getSenderRole()).isEqualTo(senderRole);
+                softAssertion.assertThat(result.getMessage()).isEqualTo(message);
+            });
         }
 
         @Test
@@ -52,11 +57,15 @@ class ChatMessageTest {
             String message = "악".repeat(1000);
 
             // when
-            Exception exception = catchException(
-                () -> new ChatMessage(chatRoom, senderId, senderRole, message));
+            ChatMessage result = new ChatMessage(chatRoom, senderId, senderRole, message);
 
             // then
-            assertThat(exception).isNull();
+            assertSoftly(softAssertion -> {
+                softAssertion.assertThat(result.getChatRoom()).isEqualTo(chatRoom);
+                softAssertion.assertThat(result.getSenderId()).isEqualTo(senderId);
+                softAssertion.assertThat(result.getSenderRole()).isEqualTo(senderRole);
+                softAssertion.assertThat(result.getMessage()).isEqualTo(message);
+            });
         }
 
         @Test

--- a/src/test/java/com/clova/anifriends/domain/chat/controller/WebSocketStompTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/controller/WebSocketStompTest.java
@@ -1,0 +1,145 @@
+package com.clova.anifriends.domain.chat.controller;
+
+import static com.clova.anifriends.domain.auth.jwt.UserRole.ROLE_VOLUNTEER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.clova.anifriends.domain.chat.ChatMessage;
+import com.clova.anifriends.domain.chat.ChatRoom;
+import com.clova.anifriends.domain.chat.message.pub.NewChatMessagePub;
+import com.clova.anifriends.domain.chat.message.sub.ChatMessageSub;
+import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
+import com.clova.anifriends.domain.chat.support.ChatMessageFixture;
+import com.clova.anifriends.domain.chat.support.ChatRoomFixture;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
+import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebSocketStompTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ShelterRepository shelterRepository;
+
+    @Autowired
+    private VolunteerRepository volunteerRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    private BlockingQueue<NewChatMessagePub> messages;
+
+    private String url;
+
+    @BeforeEach
+    void setUp() {
+        url = "ws://localhost:" + port + "/ws-stomp";
+        messages = new LinkedBlockingDeque<>();
+
+        Volunteer volunteer = VolunteerFixture.volunteer();
+        Shelter shelter = ShelterFixture.shelter();
+        ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+
+        volunteerRepository.save(volunteer);
+        shelterRepository.save(shelter);
+        chatRoomRepository.save(chatRoom);
+    }
+
+    @Test
+    void test() throws Exception {
+        // given
+        StompSession stompSession = getStompSession();
+        Volunteer volunteer = volunteerRepository.findAll().get(0);
+        Shelter shelter = shelterRepository.findAll().get(0);
+        ChatRoom chatRoom = chatRoomRepository.findAll().get(0);
+
+        ChatMessage chatMessage = ChatMessageFixture.chatMessage(chatRoom,
+            volunteer.getVolunteerId(), ROLE_VOLUNTEER);
+
+        NewChatMessagePub.from(chatMessage);
+
+        stompSession.subscribe("/sub/new/chat/rooms/shelters/" + shelter.getShelterId(),
+            new StompFrameHandlerImpl<>(NewChatMessagePub.from(chatMessage), messages));
+        System.out.println("/sub/new/chat/rooms/shelters/" + shelter.getShelterId());
+        // when
+        stompSession.send("/pub/new/chat/rooms/" + chatRoom.getChatRoomId() + "/shelters/"
+                + shelter.getShelterId(),
+            new ChatMessageSub(volunteer.getVolunteerId(), ROLE_VOLUNTEER,
+                chatMessage.getMessage()));
+        NewChatMessagePub message = messages.poll(5, TimeUnit.SECONDS);
+
+        // then
+        assertThat(message).usingRecursiveComparison()
+            .ignoringFields("chatMessage.createdAt")
+            .isEqualTo(NewChatMessagePub.from(chatMessage));
+    }
+
+    class StompFrameHandlerImpl<T> implements StompFrameHandler {
+
+        private final T response;
+        private final BlockingQueue<T> responses;
+
+        public StompFrameHandlerImpl(final T response, final BlockingQueue<T> responses) {
+            this.response = response;
+            this.responses = responses;
+        }
+
+        @Override
+        public Type getPayloadType(final StompHeaders headers) {
+            return response.getClass();
+        }
+
+        @Override
+        public void handleFrame(final StompHeaders headers, final Object payload) {
+            responses.offer((T) payload);
+        }
+    }
+
+    private StompSession getStompSession()
+        throws ExecutionException, InterruptedException, TimeoutException {
+        StandardWebSocketClient standardWebSocketClient = new StandardWebSocketClient();
+        WebSocketTransport webSocketTransport = new WebSocketTransport(standardWebSocketClient);
+        SockJsClient sockJsClient = new SockJsClient(List.of(webSocketTransport));
+        WebSocketStompClient webSocketStompClient = new WebSocketStompClient(sockJsClient);
+
+        MappingJackson2MessageConverter messageConverter = new MappingJackson2MessageConverter();
+        ObjectMapper objectMapper = messageConverter.getObjectMapper();
+        objectMapper.registerModules(new JavaTimeModule(), new ParameterNamesModule());
+        webSocketStompClient.setMessageConverter(messageConverter);
+
+        return webSocketStompClient
+            .connectAsync(url, new StompSessionHandlerAdapter() {
+            })
+            .get(2, TimeUnit.SECONDS);
+    }
+
+}

--- a/src/test/java/com/clova/anifriends/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,94 @@
+package com.clova.anifriends.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.chat.ChatMessage;
+import com.clova.anifriends.domain.chat.ChatRoom;
+import com.clova.anifriends.domain.chat.exception.ChatRoomNotFoundException;
+import com.clova.anifriends.domain.chat.message.pub.NewChatMessagePub;
+import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
+import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
+import com.clova.anifriends.domain.chat.support.ChatMessageFixture;
+import com.clova.anifriends.domain.chat.support.ChatRoomFixture;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Nested
+    @DisplayName("registerChatMessage 메소드는")
+    class RegisterMessageTest {
+
+        @Test
+        @DisplayName("성공")
+        void registerChatMessage() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            ChatRoom chatRoom = ChatRoomFixture.chatRoom(volunteer, shelter);
+            UserRole senderRole = UserRole.ROLE_VOLUNTEER;
+            Long senderId = 1L;
+
+            ChatMessage chatMessage = ChatMessageFixture.chatMessage(chatRoom, senderId,
+                senderRole);
+            NewChatMessagePub expect = NewChatMessagePub.from(chatMessage);
+
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(chatRoom));
+
+            // when
+            NewChatMessagePub result = chatMessageService.registerChatMessage(1L,
+                chatMessage.getSenderId(), chatMessage.getSenderRole(), chatMessage.getMessage());
+
+            // then
+            verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+            assertThat(result).usingRecursiveComparison().isEqualTo(expect);
+
+        }
+
+        @Test
+        @DisplayName("예외(ChatRoomNotFoundException): 채팅방이 존재하지 않을 경우")
+        void exceptionWhenChatRoomIsNotExist() {
+            // given
+            UserRole senderRole = UserRole.ROLE_VOLUNTEER;
+            String message = "악";
+
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            Exception exception = catchException(
+                () -> chatMessageService.registerChatMessage(1L, 1L, senderRole, message));
+
+            // then
+            assertThat(exception).isInstanceOf(ChatRoomNotFoundException.class);
+        }
+    }
+
+
+}

--- a/src/test/java/com/clova/anifriends/domain/chat/support/ChatMessageFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/support/ChatMessageFixture.java
@@ -1,0 +1,15 @@
+package com.clova.anifriends.domain.chat.support;
+
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.chat.ChatMessage;
+import com.clova.anifriends.domain.chat.ChatRoom;
+
+public class ChatMessageFixture {
+
+    public static final String CHAT_MESSAGE = "chatMessage";
+
+    public static ChatMessage chatMessage(ChatRoom chatRoom, Long senderId, UserRole senderRole) {
+        return new ChatMessage(chatRoom, senderId, senderRole, CHAT_MESSAGE);
+    }
+
+}


### PR DESCRIPTION
### ⛏ 작업 사항
새로운 채팅방에서 메시지 발생 시 메시지를 publish 처리를 하였습니다.

### 📝 작업 요약
- 새로운 채팅방 생성 시 클라이언트에서 `/pub/new/chat/rooms/{chatRoomId}/shelters/{shelterId}` 로 메시지 전송
- 서버에서는 메시지를 저장하고 `/sub/new/chat/rooms/shelters/{shelterId}` 로 메시지 발행 처리
- 서버와 클라이언트의 STOMP pub/sub 메시지를 검증하는 테스트코드 작성

### Apic 으로 stomp 테스트를 진행하였습니다.
1. 클라이언트에서 `/pub/new/chat/rooms/{chatRoomId}/shelters/{shelterId}` 로 메시지 PUB
<img width="800" alt="KakaoTalk_Photo_2023-11-17-15-12-22 002png" src="https://github.com/Anifriends/Anifriends-Backend/assets/97938489/cb0bd315-f418-49d1-9cb5-9c7b5532cbcb">

2. 서버에서 `/sub/new/chat/rooms/shelters/{shelterId}` 로 메시지 PUB
(서버측에서 메시지를 PUB할때 목데이터를 사용하여 발신 메시지와 수신 메시지가 다릅니다.)
<img width="1084" alt="KakaoTalk_Photo_2023-11-17-15-12-21 001png" src="https://github.com/Anifriends/Anifriends-Backend/assets/97938489/bae4577a-4513-46c2-96a8-4ddfe9890ecc">

### 💡 관련 이슈
- close #225 
