### PR TITLE
feat: 보호소 알림 읽음 처리 API를 구현한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationController.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationController.java
@@ -7,6 +7,7 @@ import com.clova.anifriends.domain.notification.service.ShelterNotificationServi
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,5 +31,13 @@ public class ShelterNotificationController {
     ) {
         return ResponseEntity.ok(
             shelterNotificationService.findShelterHasNewNotification(shelterId));
+    }
+
+    @PatchMapping("/shelters/notification/read")
+    public ResponseEntity<Void> updateNotificationRead(
+        @LoginUser Long shelterId
+    ) {
+        shelterNotificationService.updateNotificationRead(shelterId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepository.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.notification.repository;
 import com.clova.anifriends.domain.notification.ShelterNotification;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +13,10 @@ public interface ShelterNotificationRepository extends JpaRepository<ShelterNoti
 
     @Query("select exists (select s from ShelterNotification s where s.shelter.shelterId = :shelterId and s.isRead.isRead = false)")
     boolean hasNewNotification(@Param("shelterId") Long shelterId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update ShelterNotification s set s.isRead.isRead = true "
+        + "where s.shelter.shelterId = :shelterId and s.isRead.isRead = false")
+    void updateBulkRead(@Param("shelterId") Long shelterId);
+
 }

--- a/src/main/java/com/clova/anifriends/domain/notification/service/ShelterNotificationService.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/service/ShelterNotificationService.java
@@ -27,4 +27,9 @@ public class ShelterNotificationService {
         return FindShelterHasNewNotificationResponse.from(
             shelterNotificationRepository.hasNewNotification(shelterId));
     }
+
+    @Transactional
+    public void updateNotificationRead(Long shelterId) {
+        shelterNotificationRepository.updateBulkRead(shelterId);
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/controller/ShelterNotificationControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.clova.anifriends.base.BaseControllerTest;
@@ -71,7 +72,7 @@ class ShelterNotificationControllerTest extends BaseControllerTest {
     }
 
     @Test
-    @DisplayName("성공")
+    @DisplayName("성공: 보호소 새로운 알림 여부 조회 api 호출 시")
     void findShelterHasNewNotification() throws Exception {
         // given
         FindShelterHasNewNotificationResponse findShelterHasNewNotificationResponse = FindShelterHasNewNotificationResponse.from(
@@ -93,6 +94,25 @@ class ShelterNotificationControllerTest extends BaseControllerTest {
                 ),
                 responseFields(
                     fieldWithPath("hasNewNotification").type(BOOLEAN).description("새로운 알림 존재 여부")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 보호소 알림 읽음 처리 api 호출 시")
+    void updateNotificationRead() throws Exception {
+        // given
+        // when
+        ResultActions result = mockMvc.perform(patch("/api/shelters/notification/read")
+            .header(AUTHORIZATION, shelterAccessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isNoContent())
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION).description("보호소 액세스 토큰")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/repository/ShelterNotificationRepositoryTest.java
@@ -10,6 +10,7 @@ import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,10 +27,14 @@ class ShelterNotificationRepositoryTest extends BaseRepositoryTest {
         void findByShelter_ShelterIdOrderByCreatedAtDesc() {
             // given
             Shelter shelter = ShelterFixture.shelter();
-            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(shelter);
-            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(shelter);
-            ReflectionTestUtils.setField(notification1, "createdAt", LocalDateTime.now().minusDays(3));
-            ReflectionTestUtils.setField(notification2, "createdAt", LocalDateTime.now().minusDays(1));
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+            ReflectionTestUtils.setField(notification1, "createdAt",
+                LocalDateTime.now().minusDays(3));
+            ReflectionTestUtils.setField(notification2, "createdAt",
+                LocalDateTime.now().minusDays(1));
 
             shelterRepository.save(shelter);
             shelterNotificationRepository.save(notification1);
@@ -54,8 +59,10 @@ class ShelterNotificationRepositoryTest extends BaseRepositoryTest {
         void hasNewNotificationFalse() {
             // given
             Shelter shelter = ShelterFixture.shelter();
-            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(shelter);
-            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(shelter);
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(
+                shelter);
             NotificationRead notificationRead = new NotificationRead(true);
             ReflectionTestUtils.setField(notification1, "isRead", notificationRead);
             ReflectionTestUtils.setField(notification2, "isRead", notificationRead);
@@ -65,7 +72,8 @@ class ShelterNotificationRepositoryTest extends BaseRepositoryTest {
             shelterNotificationRepository.save(notification2);
 
             // when
-            boolean expected = shelterNotificationRepository.hasNewNotification(shelter.getShelterId());
+            boolean expected = shelterNotificationRepository.hasNewNotification(
+                shelter.getShelterId());
 
             // then
             assertThat(expected).isFalse();
@@ -76,8 +84,10 @@ class ShelterNotificationRepositoryTest extends BaseRepositoryTest {
         void hasNewNotificationTrue() {
             // given
             Shelter shelter = ShelterFixture.shelter();
-            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(shelter);
-            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(shelter);
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(
+                shelter);
             NotificationRead notificationRead = new NotificationRead(true);
             ReflectionTestUtils.setField(notification1, "isRead", notificationRead);
 
@@ -86,10 +96,42 @@ class ShelterNotificationRepositoryTest extends BaseRepositoryTest {
             shelterNotificationRepository.save(notification2);
 
             // when
-            boolean expected = shelterNotificationRepository.hasNewNotification(shelter.getShelterId());
+            boolean expected = shelterNotificationRepository.hasNewNotification(
+                shelter.getShelterId());
 
             // then
             assertThat(expected).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateBulkRead 실행 시")
+    class UpdateBulkReadTest {
+
+        @Test
+        @DisplayName("성공")
+        void updateBulkRead() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+
+            shelterRepository.save(shelter);
+            shelterNotificationRepository.save(notification1);
+            shelterNotificationRepository.save(notification2);
+
+            // when
+            shelterNotificationRepository.updateBulkRead(shelter.getShelterId());
+
+            // then
+            Optional<ShelterNotification> found1 = shelterNotificationRepository.findById(
+                notification1.getShelterNotificationId());
+            Optional<ShelterNotification> found2 = shelterNotificationRepository.findById(
+                notification2.getShelterNotificationId());
+            assertThat(found1.get().getIsRead()).isTrue();
+            assertThat(found2.get().getIsRead()).isTrue();
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/notification/service/ShelterNotificationServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/service/ShelterNotificationServiceTest.java
@@ -90,10 +90,6 @@ class ShelterNotificationServiceTest {
             // given
             Shelter shelter = ShelterFixture.shelter();
             ReflectionTestUtils.setField(shelter, "shelterId", 1L);
-            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(
-                shelter);
-            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(
-                shelter);
 
             // when
             shelterNotificationService.updateNotificationRead(shelter.getShelterId());

--- a/src/test/java/com/clova/anifriends/domain/notification/service/ShelterNotificationServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/notification/service/ShelterNotificationServiceTest.java
@@ -3,6 +3,8 @@ package com.clova.anifriends.domain.notification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.clova.anifriends.domain.notification.ShelterNotification;
 import com.clova.anifriends.domain.notification.dto.response.FindShelterHasNewNotificationResponse;
@@ -65,14 +67,40 @@ class ShelterNotificationServiceTest {
         @DisplayName("성공")
         void findShelterHasNewNotification() {
             // given
-            FindShelterHasNewNotificationResponse expected = FindShelterHasNewNotificationResponse.from(true);
+            FindShelterHasNewNotificationResponse expected = FindShelterHasNewNotificationResponse.from(
+                true);
             given(shelterNotificationRepository.hasNewNotification(anyLong())).willReturn(true);
 
             // when
-            FindShelterHasNewNotificationResponse result = shelterNotificationService.findShelterHasNewNotification(1L);
+            FindShelterHasNewNotificationResponse result = shelterNotificationService.findShelterHasNewNotification(
+                1L);
 
             // then
             assertThat(result).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateNotificationRead 메서드 실행 시")
+    class UpdateNotificationReadTest {
+
+        @Test
+        @DisplayName("성공")
+        void updateNotificationRead() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            ReflectionTestUtils.setField(shelter, "shelterId", 1L);
+            ShelterNotification notification1 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+            ShelterNotification notification2 = ShelterNotificationFixture.shelterNotification(
+                shelter);
+
+            // when
+            shelterNotificationService.updateNotificationRead(shelter.getShelterId());
+
+            // then
+            verify(shelterNotificationRepository, times(1))
+                .updateBulkRead(shelter.getShelterId());
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
보호소 알림 읽음 처리 API 구현

### 📝 작업 요약
- 해당 보호소의 안 읽음 알림들을 모두 읽음 처리하는 쿼리, 테스트 코드 작성
- 컨트롤러단, 서비스단 메서드 작성
- 테스트 코드 작성

### 💡 관련 이슈
- close #219 
