### PR TITLE
feat: 채팅방ID를 조회하는 기능을 구현한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.chat.controller;
 import com.clova.anifriends.domain.auth.LoginUser;
 import com.clova.anifriends.domain.chat.dto.request.RegisterChatRoomRequest;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomDetailResponse;
+import com.clova.anifriends.domain.chat.dto.response.FindChatRoomIdResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomsResponse;
 import com.clova.anifriends.domain.chat.service.ChatRoomService;
 import java.net.URI;
@@ -47,5 +48,13 @@ public class ChatRoomController {
 
         URI location = URI.create("/api/volunteers/chat/rooms/" + chatRoomId);
         return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping("/volunteers/chat/rooms/shelters/{shelterId}")
+    public ResponseEntity<FindChatRoomIdResponse> findChatRoomId(
+        @LoginUser Long volunteerId,
+        @PathVariable Long shelterId
+    ) {
+        return ResponseEntity.ok(chatRoomService.findChatRoomId(volunteerId, shelterId));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/chat/dto/response/FindChatRoomIdResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/dto/response/FindChatRoomIdResponse.java
@@ -1,0 +1,7 @@
+package com.clova.anifriends.domain.chat.dto.response;
+
+public record FindChatRoomIdResponse(
+    Long chatRoomId
+) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.chat.repository;
 
 import com.clova.anifriends.domain.chat.ChatRoom;
 import com.clova.anifriends.domain.chat.repository.response.FindChatRoomResult;
+import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +36,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         + "select max(cm2.createdAt) from ChatMessage cm2"
         + " where cm2.chatRoom = cr)")
     List<FindChatRoomResult> findChatRoomsByVolunteer(@Param("volunteer") Volunteer volunteer);
+
+    Optional<ChatRoom> findByVolunteerAndShelter(Volunteer volunteer, Shelter shelter);
 }

--- a/src/main/java/com/clova/anifriends/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.chat.service;
 import com.clova.anifriends.domain.auth.jwt.UserRole;
 import com.clova.anifriends.domain.chat.ChatRoom;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomDetailResponse;
+import com.clova.anifriends.domain.chat.dto.response.FindChatRoomIdResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomsResponse;
 import com.clova.anifriends.domain.chat.exception.ChatNotFoundException;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
@@ -35,11 +36,6 @@ public class ChatRoomService {
         return FindChatRoomDetailResponse.fromVolunteer(chatRoom);
     }
 
-    private ChatRoom getChatRoomWithShelter(Long chatRoomId) {
-        return chatRoomRepository.findByIdWithShelter(chatRoomId)
-            .orElseThrow(() -> new ChatNotFoundException("존재하지 않는 채팅방입니다."));
-    }
-
     @Transactional
     public Long registerChatRoom(Long volunteerId, Long shelterId) {
         Volunteer volunteer = getVolunteer(volunteerId);
@@ -51,12 +47,6 @@ public class ChatRoomService {
         return chatRoom.getChatRoomId();
     }
 
-    private Shelter getShelter(Long shelterId) {
-        return shelterRepository
-            .findById(shelterId)
-            .orElseThrow(() -> new ShelterNotFoundException("보호소가 존재하지 않습니다."));
-    }
-
     @Transactional(readOnly = true)
     public FindChatRoomsResponse findChatRoomsByVolunteer(Long volunteerId) {
         Volunteer volunteer = getVolunteer(volunteerId);
@@ -65,8 +55,31 @@ public class ChatRoomService {
         return ChatRoomMapper.toResponse(findChatRoomResult);
     }
 
+    @Transactional(readOnly = true)
+    public FindChatRoomIdResponse findChatRoomId(Long volunteerId, Long shelterId) {
+        Volunteer volunteer = getVolunteer(volunteerId);
+        Shelter shelter = getShelter(shelterId);
+
+        Long chatRoomId = chatRoomRepository.findByVolunteerAndShelter(volunteer, shelter)
+            .map(ChatRoom::getChatRoomId)
+            .orElse(null);
+
+        return new FindChatRoomIdResponse(chatRoomId);
+    }
+
+    private ChatRoom getChatRoomWithShelter(Long chatRoomId) {
+        return chatRoomRepository.findByIdWithShelter(chatRoomId)
+            .orElseThrow(() -> new ChatNotFoundException("존재하지 않는 채팅방입니다."));
+    }
+
     private Volunteer getVolunteer(Long volunteerId) {
         return volunteerRepository.findById(volunteerId)
             .orElseThrow(() -> new VolunteerNotFoundException("존재하지 않는 봉사자입니다."));
+    }
+
+    private Shelter getShelter(Long shelterId) {
+        return shelterRepository
+            .findById(shelterId)
+            .orElseThrow(() -> new ShelterNotFoundException("보호소가 존재하지 않습니다."));
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/chat/support/ChatRoomFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/support/ChatRoomFixture.java
@@ -3,10 +3,13 @@ package com.clova.anifriends.domain.chat.support;
 import com.clova.anifriends.domain.chat.ChatRoom;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.volunteer.Volunteer;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class ChatRoomFixture {
 
     public static ChatRoom chatRoom(Volunteer volunteer, Shelter shelter) {
-        return new ChatRoom(volunteer, shelter);
+        ChatRoom chatRoom = new ChatRoom(volunteer, shelter);
+        ReflectionTestUtils.setField(chatRoom, "chatRoomId", 1L);
+        return chatRoom;
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
채팅방ID를 조회하는 기능을 구현한다.

### 📝 작업 요약
- 채팅방을 조회하는 레포지토리 구현
- 기존의 채팅방이 존재하면 chatRoomId, 존재하지 않는다면 null을 반환하는 서비스 및 컨트롤러 작성
- 서비스와 컨트롤러 테스트코드 작성

### 💡 관련 이슈
- close #201 
