### PR TITLE
feat: 스프링 시큐리티 역할 기반 api 필터링 시 응답 메시지 내용을 커스텀한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/global/config/SecurityConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/SecurityConfig.java
@@ -2,8 +2,10 @@ package com.clova.anifriends.global.config;
 
 import com.clova.anifriends.domain.auth.authentication.JwtAuthenticationProvider;
 import com.clova.anifriends.domain.common.CustomPasswordEncoder;
+import com.clova.anifriends.global.security.authorize.UnauthorizedEntryPoint;
 import com.clova.anifriends.global.security.passwordencoder.BCryptCustomPasswordEncoder;
 import com.clova.anifriends.global.web.filter.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -40,7 +42,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(
         HttpSecurity http,
-        JwtAuthenticationProvider jwtAuthenticationProvider) throws Exception {
+        JwtAuthenticationProvider jwtAuthenticationProvider,
+        ObjectMapper objectMapper) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
@@ -65,6 +68,8 @@ public class SecurityConfig {
                 config.setMaxAge(3600L);
                 return config;
             }))
+            .exceptionHandling(exception ->
+                exception.authenticationEntryPoint(new UnauthorizedEntryPoint(objectMapper)))
             .authorizeHttpRequests(request ->
                 request
                     .requestMatchers(HttpMethod.GET, "/api/shelters/me/**").hasRole(ROLE_SHELTER)

--- a/src/main/java/com/clova/anifriends/global/security/authorize/UnauthorizedEntryPoint.java
+++ b/src/main/java/com/clova/anifriends/global/security/authorize/UnauthorizedEntryPoint.java
@@ -1,0 +1,32 @@
+package com.clova.anifriends.global.security.authorize;
+
+import com.clova.anifriends.global.exception.ErrorCode;
+import com.clova.anifriends.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UnauthorizedEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+        log.debug("[Unauthorized] {} 요청이 거부되었습니다.", request.getRequestURI());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.UN_AUTHORIZATION.getValue(),
+            "권한이 없습니다.");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/test/java/com/clova/anifriends/global/security/authorize/UnauthorizedEntryPointTest.java
+++ b/src/test/java/com/clova/anifriends/global/security/authorize/UnauthorizedEntryPointTest.java
@@ -1,0 +1,35 @@
+package com.clova.anifriends.global.security.authorize;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.clova.anifriends.base.BaseControllerTest;
+import com.clova.anifriends.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+
+class UnauthorizedEntryPointTest extends BaseControllerTest {
+
+    @Nested
+    @DisplayName("commence 메서드 호출 시")
+    class CommenceTest {
+
+        @Test
+        @DisplayName("성공")
+        void commence() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/shelters/recruitments"));
+
+            //then
+            resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.UN_AUTHORIZATION.getValue()))
+                .andExpect(jsonPath("$.message").isString());
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 스프링 시큐리티 역할 기반 api 필터링 시 접근 권한이 없는 경우의 응답 메시지를 커스터마이징하였습니다.

### 📝 작업 요약
- UnauthorizedEntryPoint 구현 및 SecuriyConfig에 추가

### 💡 관련 이슈
- close #257 
