### PR TITLE
feat: 비밀번호 변경 시 실패에 대한 에러코드를 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/shelter/wrapper/ShelterPassword.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/wrapper/ShelterPassword.java
@@ -1,9 +1,8 @@
 package com.clova.anifriends.domain.shelter.wrapper;
 
-import static java.util.Objects.isNull;
-
 import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.shelter.exception.ShelterBadRequestException;
+import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.text.MessageFormat;
@@ -55,8 +54,9 @@ public class ShelterPassword {
     private void checkOldPasswordEquals(
         String rawOldPassword,
         CustomPasswordEncoder passwordEncoder) {
-        if(passwordEncoder.noneMatchesPassword(rawOldPassword, password)) {
-            throw new ShelterBadRequestException("비밀번호가 일치하지 않습니다.");
+        if (passwordEncoder.noneMatchesPassword(rawOldPassword, password)) {
+            throw new ShelterBadRequestException(ErrorCode.OLD_PASSWORD_NOT_EQUALS_PREVIOUS,
+                "비밀번호가 일치하지 않습니다.");
         }
     }
 
@@ -64,7 +64,8 @@ public class ShelterPassword {
         String rawNewPassword,
         CustomPasswordEncoder passwordEncoder) {
         if (passwordEncoder.matchesPassword(rawNewPassword, password)) {
-            throw new ShelterBadRequestException("변경하려는 패스워드와 기존 패스워드가 동일합니다.");
+            throw new ShelterBadRequestException(ErrorCode.NEW_PASSWORD_EQUALS_PREVIOUS,
+                "변경하려는 패스워드와 기존 패스워드가 동일합니다.");
         }
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPassword.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/wrapper/VolunteerPassword.java
@@ -57,7 +57,8 @@ public class VolunteerPassword {
         String rawOldPassword,
         CustomPasswordEncoder passwordEncoder) {
         if (passwordEncoder.noneMatchesPassword(rawOldPassword, password)) {
-            throw new VolunteerBadRequestException(ErrorCode.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+            throw new VolunteerBadRequestException(ErrorCode.OLD_PASSWORD_NOT_EQUALS_PREVIOUS,
+                "비밀번호가 일치하지 않습니다.");
         }
     }
     
@@ -65,7 +66,7 @@ public class VolunteerPassword {
         String rawNewPassword,
         CustomPasswordEncoder passwordEncoder) {
         if (passwordEncoder.matchesPassword(rawNewPassword, password)) {
-            throw new VolunteerBadRequestException(ErrorCode.BAD_REQUEST,
+            throw new VolunteerBadRequestException(ErrorCode.NEW_PASSWORD_EQUALS_PREVIOUS,
                 "변경하려는 패스워드와 기존 패스워드가 동일합니다.");
         }
     }

--- a/src/main/java/com/clova/anifriends/global/exception/ErrorCode.java
+++ b/src/main/java/com/clova/anifriends/global/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode implements EnumType {
     // 400
     BAD_REQUEST("AF001"), // 잘못된 입력값
     INVALID_AUTH_INFO("AF002"), // 아이디 비밀번호 매치 안됨
+    NEW_PASSWORD_EQUALS_PREVIOUS("AF003"), // 변경하려는 비밀번호가 이전과 같음
+    OLD_PASSWORD_NOT_EQUALS_PREVIOUS("AF004"), // 비밀번호 입력값이 기존 비밀번호와 일치하지 않음
     // 401
     ACCESS_TOKEN_EXPIRED("AF101"), // 액세스 토큰 만료
     UN_AUTHENTICATION("AF102"), // 인증 안됨


### PR DESCRIPTION
### ⛏ 작업 사항
- 프론트 요청에 따라 비밀번호 변경 시 발생할 수 있는 에러 코드를 추가했습니다.
- 비밀번호 변경 로직에서 추가한 에러코드를 적용하였습니다.

### 📝 작업 요약
- ErrorCode 값 추가
- 비밀번호 변경 로직 수정

### 💡 관련 이슈
- close #256 
