### PR TITLE
feat: 안읽은 메시지 총 개수를 조회한다.(보호소) 

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -199,6 +199,16 @@ operation::chat-room-controller-test/find-chat-room-detail-by-shelter[snippets='
 
 operation::chat-room-controller-test/find-chat-room-detail-by-shelter[snippets='http-response,response-fields']
 
+=== 안 읽은 메시지 총 수 조회
+
+==== Request
+
+operation::chat-room-controller-test/find-unread-count-by-shelter[snippets='http-request,request-headers']
+
+==== Response
+
+operation::chat-room-controller-test/find-unread-count-by-shelter[snippets='http-response,response-fields']
+
 = 봉사자
 
 == 1. 봉사자

--- a/src/main/java/com/clova/anifriends/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/controller/ChatRoomController.java
@@ -77,6 +77,14 @@ public class ChatRoomController {
         return ResponseEntity.ok(findUnreadCountResponse);
     }
 
+    @GetMapping("/shelters/chat/rooms/unread")
+    public ResponseEntity<FindUnreadCountResponse> findUnreadCountByShelter(
+        @LoginUser Long shelterId) {
+        FindUnreadCountResponse findUnreadCountResponse
+            = chatRoomService.findUnreadCountByShelter(shelterId);
+        return ResponseEntity.ok(findUnreadCountResponse);
+    }
+
     @GetMapping("/chat/rooms/{chatRoomId}/messages")
     public ResponseEntity<FindChatMessagesResponse> findChatMessages(
         @PathVariable Long chatRoomId,

--- a/src/main/java/com/clova/anifriends/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.chat.repository;
 import com.clova.anifriends.domain.auth.jwt.UserRole;
 import com.clova.anifriends.domain.chat.ChatMessage;
 import com.clova.anifriends.domain.chat.ChatRoom;
+import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +27,14 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         + " and cm.senderRole = com.clova.anifriends.domain.auth.jwt.UserRole.ROLE_SHELTER"
         + " group by cm.isRead"
         + " having cm.isRead = false")
-    long findUnreadCount(@Param("volunteer") Volunteer volunteer);
+    long findUnreadCountByVolunteer(@Param("volunteer") Volunteer volunteer);
+
+    @Query("select count(cm.chatMessageId) from ChatMessage cm"
+        + " where cm.chatRoom.shelter = :shelter"
+        + " and cm.senderRole = com.clova.anifriends.domain.auth.jwt.UserRole.ROLE_SHELTER"
+        + " group by cm.isRead"
+        + " having cm.isRead = false")
+    long findUnreadCountByShelter(@Param("shelter")Shelter shelter);
 
     Page<ChatMessage> findByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom, Pageable pageable);
 }

--- a/src/main/java/com/clova/anifriends/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/service/ChatRoomService.java
@@ -97,8 +97,15 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public FindUnreadCountResponse findUnreadCountByVolunteer(Long volunteerId) {
         Volunteer volunteer = getVolunteer(volunteerId);
-        long unreadCount = chatMessageRepository.findUnreadCount(volunteer);
-        return FindUnreadCountResponse.from(unreadCount);
+        long unreadCountByVolunteer = chatMessageRepository.findUnreadCountByVolunteer(volunteer);
+        return FindUnreadCountResponse.from(unreadCountByVolunteer);
+    }
+
+    @Transactional(readOnly = true)
+    public FindUnreadCountResponse findUnreadCountByShelter(Long shelterId) {
+        Shelter shelter = getShelter(shelterId);
+        long unreadCountByShelter = chatMessageRepository.findUnreadCountByShelter(shelter);
+        return FindUnreadCountResponse.from(unreadCountByShelter);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/clova/anifriends/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/controller/ChatRoomControllerTest.java
@@ -348,4 +348,29 @@ class ChatRoomControllerTest extends BaseControllerTest {
                 )
             ));
     }
+
+    @Test
+    @DisplayName("성공: 안 읽은 메시지 총 수 조회(보호소) api 호출 시")
+    void findUnreadCountByShelter() throws Exception {
+        //given
+        FindUnreadCountResponse findUnreadCountResponse = new FindUnreadCountResponse(5);
+
+        given(chatRoomService.findUnreadCountByShelter(anyLong()))
+            .willReturn(findUnreadCountResponse);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/shelters/chat/rooms/unread")
+            .header(AUTHORIZATION, shelterAccessToken));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION).description("보호소 액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("totalUnreadCount").type(NUMBER).description("안 읽은 메시지 총 개수")
+                )
+            ));
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/repository/ChatMessageRepositoryTest.java
@@ -114,7 +114,7 @@ class ChatMessageRepositoryTest extends BaseRepositoryTest {
             chatMessageRepository.saveAll(chatMessagesByVolunteer);
 
             //when
-            Long unreadCount = chatMessageRepository.findUnreadCount(volunteer);
+            Long unreadCount = chatMessageRepository.findUnreadCountByVolunteer(volunteer);
 
             //then
             assertThat(unreadCount).isEqualTo(chatMessagesEachCount);

--- a/src/test/java/com/clova/anifriends/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/service/ChatRoomServiceTest.java
@@ -181,7 +181,6 @@ class ChatRoomServiceTest {
             //when
             FindChatMessagesResponse findchatMessagesResponse = chatRoomService.findChatMessages(1L,
                 pageRequest);
-            
 
             //then
             assertThat(findchatMessagesResponse.chatMessages()).hasSize(1);
@@ -405,7 +404,7 @@ class ChatRoomServiceTest {
             long unreadCount = 10;
 
             given(volunteerRepository.findById(anyLong())).willReturn(Optional.of(volunteer));
-            given(chatMessageRepository.findUnreadCount(any(Volunteer.class)))
+            given(chatMessageRepository.findUnreadCountByVolunteer(any(Volunteer.class)))
                 .willReturn(unreadCount);
 
             //when
@@ -454,6 +453,44 @@ class ChatRoomServiceTest {
             assertThat(findChatRoomDetailResponse.chatPartnerName()).isEqualTo(volunteer.getName());
             assertThat(findChatRoomDetailResponse.chatPartnerImageUrl())
                 .isEqualTo(volunteer.getVolunteerImageUrl());
+        }
+    }
+
+    @Nested
+    @DisplayName("findUnreadCountByShelter 메서드 호출 시")
+    class FindUnreadCountByShelterTest {
+
+        @Test
+        @DisplayName("성공")
+        void findUnreadCountByShelter() {
+            //given
+            Shelter shelter = ShelterFixture.shelter();
+            long unreadCount = 5;
+
+            given(shelterRepository.findById(anyLong())).willReturn(Optional.of(shelter));
+            given(chatMessageRepository.findUnreadCountByShelter(any(Shelter.class)))
+                .willReturn(unreadCount);
+
+            //when
+            FindUnreadCountResponse unreadCountByShelter = chatRoomService.findUnreadCountByShelter(
+                1L);
+
+            //then
+            assertThat(unreadCountByShelter.totalUnreadCount()).isEqualTo(unreadCount);
+        }
+
+        @Test
+        @DisplayName("예외(ShelterNotFoundException): 존재하지 않는 보호소")
+        void exceptionWhenShelterNotFound() {
+            //given
+            given(shelterRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            //when
+            Exception exception = catchException(
+                () -> chatRoomService.findUnreadCountByShelter(1L));
+
+            //then
+            assertThat(exception).isInstanceOf(ShelterNotFoundException.class);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 안 읽은 메시지 총 수 조회(보호소) 로직을 구현하였습니다.

### 📝 작업 요약
- 안 읽은 메시지 총 수 조회(보호소) api, 서비스 로직 구현

### 💡 관련 이슈
- close #221 
