### PR TITLE
refactor: 봉사자 비밀번호 변경 API 경로를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/controller/VolunteerController.java
@@ -86,7 +86,7 @@ public class VolunteerController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/volunteers/me/password")
+    @PatchMapping("/volunteers/me/passwords")
     public ResponseEntity<Void> updateVolunteerPassword(
         @LoginUser Long volunteerId,
         @RequestBody @Valid UpdateVolunteerPasswordRequest updateVolunteerPasswordRequest

--- a/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
@@ -221,7 +221,7 @@ class VolunteerControllerTest extends BaseControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(
-            RestDocumentationRequestBuilders.patch("/api/volunteers/me/password")
+            RestDocumentationRequestBuilders.patch("/api/volunteers/me/passwords")
                 .header(AUTHORIZATION, volunteerAccessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(updateVolunteerPasswordRequest)));


### PR DESCRIPTION
### ⛏ 작업 사항
- 보호소 비밀번호 변경 API 경로와 통일시키기 위해 봉사자 비밀번호 변경 API 경로를 수정했습니다. (프론트 요청사항)

### 📝 작업 요약
- 봉사자 비밀번호 변경 API 경로를 수정했습니다.

### 💡 관련 이슈
- close #263 
