### PR TITLE
feat: 보호소 모집 검색 API에서 마감 여부 필터링을 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -94,6 +94,7 @@ public class RecruitmentController {
             findRecruitmentsByShelterRequest.keyword(),
             findRecruitmentsByShelterRequest.startDate(),
             findRecruitmentsByShelterRequest.endDate(),
+            findRecruitmentsByShelterRequest.isClosed(),
             findRecruitmentsByShelterRequest.content(),
             findRecruitmentsByShelterRequest.title(),
             pageable

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
@@ -6,14 +6,17 @@ public record FindRecruitmentsByShelterRequest(
     String keyword,
     LocalDate startDate,
     LocalDate endDate,
+    Boolean isClosed,
     Boolean content,
     Boolean title
 ) {
 
-    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title) {
+    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate,
+        Boolean isClosed, Boolean content, Boolean title) {
         this.keyword = keyword;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.isClosed = isClosed;
         this.content = content == null || content;
         this.title = title == null || title;
     }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -12,7 +12,8 @@ public interface RecruitmentRepositoryCustom {
         boolean shelterNameContains, Pageable pageable);
 
     Page<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId, String keyword,
-        LocalDate startDate, LocalDate endDate, Boolean content, Boolean title, Pageable pageable);
+        LocalDate startDate, LocalDate endDate, Boolean isClosed, Boolean content, Boolean title,
+        Pageable pageable);
 
     Page<Recruitment> findRecruitmentsByShelterId(long shelterId, Pageable pageable);
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -76,7 +76,8 @@ public class RecruitmentRepositoryImpl implements
         return keyword != null ? recruitment.content.content.contains(keyword) : null;
     }
 
-    private BooleanExpression recruitmentShelterNameContains(String keyword, boolean shelterNameFilter) {
+    private BooleanExpression recruitmentShelterNameContains(String keyword,
+        boolean shelterNameFilter) {
         if (!shelterNameFilter) {
             return null;
         }
@@ -95,7 +96,8 @@ public class RecruitmentRepositoryImpl implements
     }
 
     private BooleanExpression recruitmentStartTimeLoe(LocalDate endDate) {
-        return endDate != null ? recruitment.info.startTime.loe(endDate.plusDays(1).atStartOfDay()) : null;
+        return endDate != null ? recruitment.info.startTime.loe(endDate.plusDays(1).atStartOfDay())
+            : null;
     }
 
     private BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> supplier) {
@@ -108,12 +110,14 @@ public class RecruitmentRepositoryImpl implements
 
     @Override
     public Page<Recruitment> findRecruitmentsByShelterOrderByCreatedAt(long shelterId,
-        String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title,
+        String keyword, LocalDate startDate, LocalDate endDate, Boolean isClosed, Boolean content,
+        Boolean title,
         Pageable pageable) {
 
         Predicate predicate = recruitment.shelter.shelterId.eq(shelterId)
             .and(getDateCondition(startDate, endDate))
-            .and(getKeywordCondition(keyword, content, title));
+            .and(getKeywordCondition(keyword, content, title))
+            .and(recruitmentIsClosed(isClosed));
 
         List<Recruitment> recruitments = query.selectFrom(recruitment)
             .where(predicate)

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -60,6 +60,7 @@ public class RecruitmentService {
         String keyword,
         LocalDate startDate,
         LocalDate endDate,
+        Boolean isClosed,
         Boolean content,
         Boolean title,
         Pageable pageable
@@ -69,6 +70,7 @@ public class RecruitmentService {
             keyword,
             startDate,
             endDate,
+            isClosed,
             content,
             title,
             pageable

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -256,6 +256,15 @@ class RecruitmentControllerTest extends BaseControllerTest {
     @DisplayName("findRecruitmentsByShelter 실행 시")
     void findRecruitmentsByShelter() throws Exception {
         // given
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("keyword", "겅색어");
+        params.add("startDate", LocalDate.now().toString());
+        params.add("endDate", LocalDate.now().toString());
+        params.add("isClosed", "false");
+        params.add("title", "true");
+        params.add("content", "false");
+        params.add("pageNumber", "0");
+        params.add("pageSize", "10");
         Shelter shelter = shelter();
         Recruitment recruitment = recruitment(shelter);
         setField(recruitment, "recruitmentId", 1L);
@@ -264,13 +273,14 @@ class RecruitmentControllerTest extends BaseControllerTest {
             pageResult);
 
         when(recruitmentService.findRecruitmentsByShelter(anyLong(), any(), any(), any(),
-            anyBoolean(), anyBoolean(), any()))
+            anyBoolean(), anyBoolean(), anyBoolean(), any()))
             .thenReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(
             get("/api/shelters/recruitments")
                 .header(AUTHORIZATION, shelterAccessToken)
+                .params(params)
                 .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -284,6 +294,8 @@ class RecruitmentControllerTest extends BaseControllerTest {
                         .attributes(DocumentationFormatGenerator.getDateConstraint()),
                     parameterWithName("endDate").description("검색 종료 날짜").optional()
                         .attributes(DocumentationFormatGenerator.getDateConstraint()),
+                    parameterWithName("isClosed").description("마감 여부").optional()
+                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 null")),
                     parameterWithName("content").description("내용 검색 여부").optional()
                         .attributes(DocumentationFormatGenerator.getConstraint("기본값 null")),
                     parameterWithName("title").description("제목 검색 여부").optional()

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -170,6 +170,7 @@ class RecruitmentRepositoryTest extends BaseRepositoryTest {
             LocalDate endDate = LocalDate.now().plusMonths(5);
             boolean content = true;
             boolean title = true;
+            Boolean isClosed = false;
             PageRequest pageable = PageRequest.of(0, 10);
 
             // when
@@ -178,13 +179,14 @@ class RecruitmentRepositoryTest extends BaseRepositoryTest {
                 keyword,
                 startDate,
                 endDate,
+                isClosed,
                 content,
                 title,
                 pageable
             );
 
             // then
-            assertThat(recruitments).contains(recruitment2, recruitment3);
+            assertThat(recruitments).contains(recruitment3);
         }
 
         @Test
@@ -237,6 +239,7 @@ class RecruitmentRepositoryTest extends BaseRepositoryTest {
             // when
             Page<Recruitment> recruitments = recruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
                 shelter.getShelterId(),
+                null,
                 null,
                 null,
                 null,

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -202,12 +202,12 @@ class RecruitmentServiceTest {
                 pageResult);
 
             when(recruitmentRepository.findRecruitmentsByShelterOrderByCreatedAt(
-                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any()))
+                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
                 .thenReturn(pageResult);
 
             // when
             FindRecruitmentsByShelterResponse result = recruitmentService.findRecruitmentsByShelter(
-                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any());
+                anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean(), any());
 
             // then
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);


### PR DESCRIPTION
### ⛏ 작업 사항
보호소에서 하는 모집 검색 API에 마감 여부 필터링을 추가한다.

### 📝 작업 요약
- requestDTO에 isClosed 추가
- service, controller, 쿼리 함수에 isClosed를 받게 한다.
- 쿼리 함수에서 isClosed 필터링 추가
- 관련 테스트 코드 수정

### 💡 관련 이슈
- close #253 
