### PR TITLE
refactor: 봉사 모집글 조회 키워드 필터를 enum으로 변경한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/KeywordCondition.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/KeywordCondition.java
@@ -1,0 +1,5 @@
+package com.clova.anifriends.domain.recruitment.controller;
+
+public record KeywordCondition(boolean titleFilter, boolean contentFilter, boolean shelterNameFilter) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/KeywordConditionByShelter.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/KeywordConditionByShelter.java
@@ -1,0 +1,5 @@
+package com.clova.anifriends.domain.recruitment.controller;
+
+public record KeywordConditionByShelter(boolean titleFilter, boolean contentFilter) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilter.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilter.java
@@ -1,0 +1,29 @@
+package com.clova.anifriends.domain.recruitment.controller;
+
+import com.clova.anifriends.domain.common.EnumType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum KeywordFilter implements EnumType {
+    IS_TITLE(true, false, false),
+    IS_CONTENT(false, true, false),
+    IS_SHELTER_NAME(false, false, true),
+    ALL(true, true, true);
+
+    private final boolean titleFilter;
+    private final boolean contentFilter;
+    private final boolean shelterNameFilter;
+
+    public KeywordCondition getKeywordCondition() {
+        return new KeywordCondition(titleFilter, contentFilter, shelterNameFilter);
+    }
+
+    public KeywordConditionByShelter getKeywordConditionByShelter() {
+        return new KeywordConditionByShelter(titleFilter, contentFilter);
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -71,14 +71,16 @@ public class RecruitmentController {
     public ResponseEntity<FindRecruitmentsResponse> findRecruitments(
         @ModelAttribute @Valid FindRecruitmentsRequest findRecruitmentsRequest,
         Pageable pageable) {
+        KeywordCondition keywordCondition = findRecruitmentsRequest.keywordFilter()
+            .getKeywordCondition();
         return ResponseEntity.ok(recruitmentService.findRecruitments(
             findRecruitmentsRequest.keyword(),
             findRecruitmentsRequest.startDate(),
             findRecruitmentsRequest.endDate(),
             findRecruitmentsRequest.isClosed(),
-            findRecruitmentsRequest.title(),
-            findRecruitmentsRequest.content(),
-            findRecruitmentsRequest.shelterName(),
+            keywordCondition.titleFilter(),
+            keywordCondition.contentFilter(),
+            keywordCondition.shelterNameFilter(),
             pageable
         ));
     }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -91,13 +91,15 @@ public class RecruitmentController {
         @ModelAttribute @Valid FindRecruitmentsByShelterRequest findRecruitmentsByShelterRequest,
         Pageable pageable
     ) {
+        KeywordConditionByShelter keywordConditionByShelter = findRecruitmentsByShelterRequest.keywordFilter()
+            .getKeywordConditionByShelter();
         return ResponseEntity.ok(recruitmentService.findRecruitmentsByShelter(
             shelterId,
             findRecruitmentsByShelterRequest.keyword(),
             findRecruitmentsByShelterRequest.startDate(),
             findRecruitmentsByShelterRequest.endDate(),
-            findRecruitmentsByShelterRequest.content(),
-            findRecruitmentsByShelterRequest.title(),
+            keywordConditionByShelter.contentFilter(),
+            keywordConditionByShelter.titleFilter(),
             pageable
         ));
     }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsByShelterRequest.java
@@ -1,20 +1,20 @@
 package com.clova.anifriends.domain.recruitment.dto.request;
 
+import com.clova.anifriends.domain.recruitment.controller.KeywordFilter;
 import java.time.LocalDate;
 
 public record FindRecruitmentsByShelterRequest(
     String keyword,
     LocalDate startDate,
     LocalDate endDate,
-    Boolean content,
-    Boolean title
+    KeywordFilter keywordFilter
 ) {
 
-    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate, Boolean content, Boolean title) {
+    public FindRecruitmentsByShelterRequest(String keyword, LocalDate startDate, LocalDate endDate,
+        KeywordFilter keywordFilter) {
         this.keyword = keyword;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.content = content == null || content;
-        this.title = title == null || title;
+        this.keywordFilter = keywordFilter == null ? KeywordFilter.ALL : keywordFilter;
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/request/FindRecruitmentsRequest.java
@@ -1,5 +1,6 @@
 package com.clova.anifriends.domain.recruitment.dto.request;
 
+import com.clova.anifriends.domain.recruitment.controller.KeywordFilter;
 import java.time.LocalDate;
 
 public record FindRecruitmentsRequest(
@@ -7,20 +8,16 @@ public record FindRecruitmentsRequest(
     LocalDate startDate,
     LocalDate endDate,
     Boolean isClosed,
-    Boolean title,
-    Boolean content,
-    Boolean shelterName
+    KeywordFilter keywordFilter
 ) {
 
     public FindRecruitmentsRequest(String keyword, LocalDate startDate,
         LocalDate endDate,
-        Boolean isClosed, Boolean title, Boolean content, Boolean shelterName) {
+        Boolean isClosed, KeywordFilter keywordFilter) {
         this.keyword = keyword;
         this.startDate = startDate;
         this.endDate = endDate;
         this.isClosed = isClosed;
-        this.title = title == null || title;
-        this.content = content == null || content;
-        this.shelterName = shelterName == null || shelterName;
+        this.keywordFilter = keywordFilter == null ? KeywordFilter.ALL : keywordFilter;
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilterTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilterTest.java
@@ -72,4 +72,51 @@ class KeywordFilterTest {
             assertThat(keywordCondition.shelterNameFilter()).isTrue();
         }
     }
+
+    @Nested
+    @DisplayName("getKeywordConditionByShelter 메서드 호출 시")
+    class GetKeywordConditionByShelterTest {
+
+        @Test
+        @DisplayName("성공: IS_TITLE 일 시")
+        void getKeywordConditionByShelterWhenIS_TITLE() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.IS_TITLE;
+
+            //when
+            KeywordConditionByShelter keywordConditionByShelter = keywordFilter.getKeywordConditionByShelter();
+
+            //then
+            assertThat(keywordConditionByShelter.titleFilter()).isTrue();
+            assertThat(keywordConditionByShelter.contentFilter()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: IS_CONTENT 일 시")
+        void getKeywordConditionByShelterWhenIS_CONTENT() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.IS_CONTENT;
+
+            //when
+            KeywordConditionByShelter keywordConditionByShelter = keywordFilter.getKeywordConditionByShelter();
+
+            //then
+            assertThat(keywordConditionByShelter.titleFilter()).isFalse();
+            assertThat(keywordConditionByShelter.contentFilter()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: ALL 일 시")
+        void getKeywordConditionByShelterWhenALL() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.ALL;
+
+            //when
+            KeywordConditionByShelter keywordConditionByShelter = keywordFilter.getKeywordConditionByShelter();
+
+            //then
+            assertThat(keywordConditionByShelter.titleFilter()).isTrue();
+            assertThat(keywordConditionByShelter.contentFilter()).isTrue();
+        }
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilterTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilterTest.java
@@ -1,0 +1,75 @@
+package com.clova.anifriends.domain.recruitment.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class KeywordFilterTest {
+
+    @Nested
+    @DisplayName("getKeywordCondition 메서드 호출 시")
+    class GetKeywordConditionTest {
+
+        @Test
+        @DisplayName("성공: IS_TITLE 일 시")
+        void getKeywordConditionWhenIS_TITLE() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.IS_TITLE;
+            
+            //when
+            KeywordCondition keywordCondition = keywordFilter.getKeywordCondition();
+
+            //then
+            assertThat(keywordCondition.titleFilter()).isTrue();
+            assertThat(keywordCondition.contentFilter()).isFalse();
+            assertThat(keywordCondition.shelterNameFilter()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: IS_CONTENT 일 시")
+        void getKeywordConditionWhenIS_CONTENT() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.IS_CONTENT;
+
+            //when
+            KeywordCondition keywordCondition = keywordFilter.getKeywordCondition();
+
+            //then
+            assertThat(keywordCondition.titleFilter()).isFalse();
+            assertThat(keywordCondition.contentFilter()).isTrue();
+            assertThat(keywordCondition.shelterNameFilter()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: IS_SHELTER_NAME 일 시")
+        void getKeywordConditionWhenIS_SHELTER_NAME() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.IS_SHELTER_NAME;
+
+            //when
+            KeywordCondition keywordCondition = keywordFilter.getKeywordCondition();
+
+            //then
+            assertThat(keywordCondition.titleFilter()).isFalse();
+            assertThat(keywordCondition.contentFilter()).isFalse();
+            assertThat(keywordCondition.shelterNameFilter()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: ALL 일 시")
+        void getKeywordConditionWhenALL() {
+            //given
+            KeywordFilter keywordFilter = KeywordFilter.ALL;
+
+            //when
+            KeywordCondition keywordCondition = keywordFilter.getKeywordCondition();
+
+            //then
+            assertThat(keywordCondition.titleFilter()).isTrue();
+            assertThat(keywordCondition.contentFilter()).isTrue();
+            assertThat(keywordCondition.shelterNameFilter()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilterTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/KeywordFilterTest.java
@@ -17,7 +17,7 @@ class KeywordFilterTest {
         void getKeywordConditionWhenIS_TITLE() {
             //given
             KeywordFilter keywordFilter = KeywordFilter.IS_TITLE;
-            
+
             //when
             KeywordCondition keywordCondition = keywordFilter.getKeywordCondition();
 

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -50,6 +50,7 @@ import com.clova.anifriends.domain.shelter.Shelter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -180,9 +181,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
         params.add("startDate", LocalDate.now().toString());
         params.add("endDate", LocalDate.now().toString());
         params.add("isClosed", "false");
-        params.add("title", "true");
-        params.add("content", "false");
-        params.add("shelterName", "false");
+        params.add("keywordFilter", KeywordFilter.IS_CONTENT.getName());
         params.add("pageNumber", "0");
         params.add("pageSize", "10");
         Shelter shelter = shelter();
@@ -217,12 +216,11 @@ class RecruitmentControllerTest extends BaseControllerTest {
                         .attributes(DocumentationFormatGenerator.getDateConstraint()),
                     parameterWithName("isClosed").description("마감 여부").optional()
                         .attributes(DocumentationFormatGenerator.getConstraint("true, false")),
-                    parameterWithName("title").description("제목 포함 검색").optional()
-                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 true")),
-                    parameterWithName("content").description("본문 포함 검색").optional()
-                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 true")),
-                    parameterWithName("shelterName").description("보호소 이름 포함 검색").optional()
-                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 true")),
+                    parameterWithName("keywordFilter").description("검색 필터").optional()
+                        .attributes(DocumentationFormatGenerator.getConstraint(
+                            String.join(", ", Arrays.stream(KeywordFilter.values())
+                                .map(KeywordFilter::name)
+                                .toArray(String[]::new)))),
                     parameterWithName("pageNumber").description("페이지 번호"),
                     parameterWithName("pageSize").description("페이지 사이즈")
                 ),
@@ -433,7 +431,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
     }
 
     @Test
-    @DisplayName("성공: 봉사 몾집글 수정 api 호출 시")
+    @DisplayName("성공: 봉사 모집글 수정 api 호출 시")
     void updateRecruitment() throws Exception {
         //given
         String title = "title";

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -251,7 +251,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
     }
 
     @Test
-    @DisplayName("findRecruitmentsByShelter 실행 시")
+    @DisplayName("성공: 봉사 모집글 조회(보호소) api 실행 시")
     void findRecruitmentsByShelter() throws Exception {
         // given
         Shelter shelter = shelter();
@@ -282,10 +282,10 @@ class RecruitmentControllerTest extends BaseControllerTest {
                         .attributes(DocumentationFormatGenerator.getDateConstraint()),
                     parameterWithName("endDate").description("검색 종료 날짜").optional()
                         .attributes(DocumentationFormatGenerator.getDateConstraint()),
-                    parameterWithName("content").description("내용 검색 여부").optional()
-                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 null")),
-                    parameterWithName("title").description("제목 검색 여부").optional()
-                        .attributes(DocumentationFormatGenerator.getConstraint("기본값 null")),
+                    parameterWithName("content").description("내용 검색 여부").optional(),
+                    parameterWithName("keywordFilter").description("검색 필터").optional()
+                        .attributes(
+                            DocumentationFormatGenerator.getConstraint("IS_TITLE, IS_CONTENT")),
                     parameterWithName("pageSize").description("페이지 크기").optional(),
                     parameterWithName("pageNumber").description("페이지 번호").optional()
                 ),


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사 모집글 조회 봉사자, 보호소 api의 검색 필터 파라미터를 enum 값으로 변경하였습니다.
- null이 입력으로 들어올 시 ALL 이라는 값을 반환하여 전체 검색이 수행될 수 있도록 했습니다.

### 📝 작업 요약
- `KeywordFilter` 추가

### 💡 관련 이슈
- close #281 
