### PR TITLE
feat: 봉사 모집글 상세 조회 API에 shelterId를 추가한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentDetailResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentDetailResponse.java
@@ -15,7 +15,8 @@ public record FindRecruitmentDetailResponse(
     LocalDateTime recruitmentDeadline,
     LocalDateTime recruitmentCreatedAt,
     LocalDateTime recruitmentUpdatedAt,
-    List<String> recruitmentImageUrls
+    List<String> recruitmentImageUrls,
+    Long shelterId
 
 ) {
 
@@ -31,7 +32,8 @@ public record FindRecruitmentDetailResponse(
             recruitment.getDeadline(),
             recruitment.getCreatedAt(),
             recruitment.getUpdatedAt(),
-            recruitment.getImages()
+            recruitment.getImages(),
+            recruitment.getShelter().getShelterId()
         );
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -32,4 +32,7 @@ public interface RecruitmentRepository
         + " and r.shelter.shelterId = :shelterId")
     Optional<Recruitment> findByShelterIdAndRecruitmentIdWithImages(
         @Param("shelterId") Long shelterId, @Param("recruitmentId") Long recruitmentId);
+
+    @Query("select r, r.shelter.shelterId from Recruitment r where r.recruitmentId = :recruitmentId")
+    Optional<Recruitment> findRecruitmentDetail(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -92,7 +92,8 @@ public class RecruitmentService {
 
     @Transactional(readOnly = true)
     public FindRecruitmentDetailResponse findRecruitmentDetail(long recruitmentId) {
-        Recruitment recruitment = getRecruitmentById(recruitmentId);
+        Recruitment recruitment = recruitmentRepository.findRecruitmentDetail(recruitmentId)
+            .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 모집글입니다."));
         return FindRecruitmentDetailResponse.from(recruitment);
     }
 

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -413,7 +413,8 @@ class RecruitmentControllerTest extends BaseControllerTest {
                         .optional(),
                     fieldWithPath("recruitmentUpdatedAt").type(STRING).description("모집글 업데이트 시간")
                         .optional(),
-                    fieldWithPath("recruitmentImageUrls").type(ARRAY).description("모집글 이미지 url 리스트")
+                    fieldWithPath("recruitmentImageUrls").type(ARRAY).description("모집글 이미지 url 리스트"),
+                    fieldWithPath("shelterId").type(NUMBER).description("보호소 ID")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -16,6 +16,7 @@ import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -311,6 +312,29 @@ class RecruitmentRepositoryTest extends BaseRepositoryTest {
 
             // then
             assertThat(recruitments).contains(recruitment1, recruitment2, recruitment3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findRecruitmentDetail 메서드 실행 시")
+    class FindRecruitmentDetailTest {
+
+        @Test
+        @DisplayName("성공")
+        void findRecruitmentDetail() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+
+            shelterRepository.save(shelter);
+            recruitmentRepository.save(recruitment);
+
+            // when
+            Optional<Recruitment> found = recruitmentRepository.findRecruitmentDetail(
+                recruitment.getRecruitmentId());
+
+            // then
+            assertThat(found.get().getShelter().getShelterId()).isEqualTo(shelter.getShelterId());
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -257,7 +257,7 @@ class RecruitmentServiceTest {
             Recruitment recruitment = recruitment(shelter);
             FindRecruitmentDetailResponse expected = findRecruitmentDetailResponse(recruitment);
 
-            when(recruitmentRepository.findById(anyLong())).thenReturn(Optional.of(recruitment));
+            when(recruitmentRepository.findRecruitmentDetail(anyLong())).thenReturn(Optional.of(recruitment));
 
             // when
             FindRecruitmentDetailResponse result = recruitmentService.findRecruitmentDetail(
@@ -271,7 +271,7 @@ class RecruitmentServiceTest {
         @DisplayName("예외(RecruitmentNotFoundException): 존재하지 않는 모집글")
         void throwExceptionWhenRecruitmentIsNotExist() {
             // given
-            when(recruitmentRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(recruitmentRepository.findRecruitmentDetail(anyLong())).thenReturn(Optional.empty());
 
             // when
             Exception exception = catchException(


### PR DESCRIPTION
### ⛏ 작업 사항
봉사 모집글 상세 조회 응답에 shelterId를 추가한다. 

### 📝 작업 요약
- 봉사 모집글 상세 조회 JPQL 작성
- responseDTO에 shelterId 추가
- 테스트 코드 작성 및 수정

### 💡 관련 이슈
- close #290 
