### PR TITLE
refactor: 보호동물 검색(봉사자) 로직의 페이지네이션을 커서 기반으로 개선한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
@@ -1,5 +1,6 @@
 package com.clova.anifriends.domain.animal.controller;
 
+import com.clova.anifriends.domain.animal.dto.FindAnimalsByVolunteerRequestV2;
 import com.clova.anifriends.domain.animal.dto.request.FindAnimalsByShelterRequest;
 import com.clova.anifriends.domain.animal.dto.request.FindAnimalsByVolunteerRequest;
 import com.clova.anifriends.domain.animal.dto.request.RegisterAnimalRequest;
@@ -83,6 +84,24 @@ public class AnimalController {
             findAnimalsRequest.age(),
             findAnimalsRequest.gender(),
             findAnimalsRequest.size(),
+            pageable
+        ));
+    }
+
+    @GetMapping("/v2/animals")
+    public ResponseEntity<FindAnimalsResponse> findAnimalsByVolunteerV2(
+        Pageable pageable,
+        @ModelAttribute FindAnimalsByVolunteerRequestV2 findAnimalsByVolunteerRequestV2
+    ) {
+        return ResponseEntity.ok(animalService.findAnimalsByVolunteerV2(
+            findAnimalsByVolunteerRequestV2.type(),
+            findAnimalsByVolunteerRequestV2.active(),
+            findAnimalsByVolunteerRequestV2.neuteredFilter(),
+            findAnimalsByVolunteerRequestV2.age(),
+            findAnimalsByVolunteerRequestV2.gender(),
+            findAnimalsByVolunteerRequestV2.size(),
+            findAnimalsByVolunteerRequestV2.createdAt(),
+            findAnimalsByVolunteerRequestV2.animalId(),
             pageable
         ));
     }

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/FindAnimalsByVolunteerRequestV2.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/FindAnimalsByVolunteerRequestV2.java
@@ -1,0 +1,23 @@
+package com.clova.anifriends.domain.animal.dto;
+
+import com.clova.anifriends.domain.animal.AnimalAge;
+import com.clova.anifriends.domain.animal.AnimalSize;
+import com.clova.anifriends.domain.animal.vo.AnimalActive;
+import com.clova.anifriends.domain.animal.vo.AnimalGender;
+import com.clova.anifriends.domain.animal.vo.AnimalNeuteredFilter;
+import com.clova.anifriends.domain.animal.vo.AnimalType;
+import java.time.LocalDateTime;
+
+public record FindAnimalsByVolunteerRequestV2(
+    AnimalType type,
+    AnimalGender gender,
+    AnimalNeuteredFilter neuteredFilter,
+    AnimalActive active,
+    AnimalSize size,
+    AnimalAge age,
+    Long animalId,
+    LocalDateTime createdAt
+
+) {
+
+}

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/response/FindAnimalsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/response/FindAnimalsResponse.java
@@ -4,6 +4,7 @@ import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.common.PageInfo;
 import java.util.List;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 public record FindAnimalsResponse(
     PageInfo pageInfo,
@@ -27,6 +28,7 @@ public record FindAnimalsResponse(
                 animal.getImages().get(0)
             );
         }
+
     }
 
     public static FindAnimalsResponse from(Page<Animal> pagination) {
@@ -35,6 +37,14 @@ public record FindAnimalsResponse(
             .map(FindAnimalByVolunteerResponse::from).toList();
 
         return new FindAnimalsResponse(pageInfo, findAnimalByVolunteerResponses);
+    }
+
+    public static FindAnimalsResponse fromV2(Slice<Animal> animalsWithPagination, Long count) {
+        PageInfo pageInfo = PageInfo.of(count, animalsWithPagination.hasNext());
+        List<FindAnimalByVolunteerResponse> findAnimalsResponses = animalsWithPagination.get()
+            .map(FindAnimalByVolunteerResponse::from).toList();
+
+        return new FindAnimalsResponse(pageInfo, findAnimalsResponses);
     }
 
 }

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryCustom.java
@@ -7,8 +7,10 @@ import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
 import com.clova.anifriends.domain.animal.vo.AnimalNeuteredFilter;
 import com.clova.anifriends.domain.animal.vo.AnimalType;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface AnimalRepositoryCustom {
 
@@ -33,4 +35,26 @@ public interface AnimalRepositoryCustom {
         AnimalSize size,
         Pageable pageable
     );
+
+    Slice<Animal> findAnimalsByVolunteerV2(
+        AnimalType type,
+        AnimalActive active,
+        AnimalNeuteredFilter neuteredFilter,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size,
+        LocalDateTime createdAt,
+        Long animalId,
+        Pageable pageable
+    );
+
+    Long countAnimalsV2(
+        AnimalType type,
+        AnimalActive active,
+        AnimalNeuteredFilter neuteredFilter,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size
+    );
+
 }

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.animal.repository;
 
 import static com.clova.anifriends.domain.animal.QAnimal.animal;
+import static com.clova.anifriends.domain.recruitment.QRecruitment.recruitment;
 
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.AnimalAge;
@@ -12,12 +13,15 @@ import com.clova.anifriends.domain.animal.vo.AnimalType;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -111,6 +115,86 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
             .fetchOne();
 
         return new PageImpl<>(animals, pageable, count == null ? 0 : count);
+    }
+
+    @Override
+    public Slice<Animal> findAnimalsByVolunteerV2(
+        AnimalType type,
+        AnimalActive active,
+        AnimalNeuteredFilter neuteredFilter,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size,
+        LocalDateTime createdAt,
+        Long animalId,
+        Pageable pageable
+    ) {
+        List<Animal> animals = query.selectFrom(animal)
+            .join(animal.shelter)
+            .where(
+                animalTypeContains(type),
+                animalActiveContains(active),
+                animalIsNeutered(neuteredFilter),
+                animalAgeContains(age),
+                animalGenderContains(gender),
+                animalSizeContains(size),
+                cursorId(animalId, createdAt)
+            )
+            .orderBy(animal.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1L)
+            .fetch();
+
+        boolean hasNext = hasNext(pageable.getPageSize(), animals);
+        return new SliceImpl<>(animals, pageable, hasNext);
+    }
+
+    private BooleanExpression cursorId(Long recruitmentId, LocalDateTime createdAt) {
+        if (recruitmentId == null || createdAt == null) {
+            return null;
+        }
+
+        return recruitment.createdAt.lt(createdAt)
+            .or(
+                recruitment.recruitmentId.lt(recruitmentId)
+                    .and(recruitment.createdAt.eq(createdAt)
+                    )
+            );
+    }
+
+    private boolean hasNext(int pageSize, List<Animal> animals) {
+        if (animals.size() <= pageSize) {
+            return false;
+        }
+
+        animals.remove(pageSize);
+        return true;
+    }
+
+
+    @Override
+    public Long countAnimalsV2(
+        AnimalType type,
+        AnimalActive active,
+        AnimalNeuteredFilter neuteredFilter,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size
+    ) {
+        Long count = query.select(animal.count())
+            .from(animal)
+            .join(animal.shelter)
+            .where(
+                animalTypeContains(type),
+                animalActiveContains(active),
+                animalIsNeutered(neuteredFilter),
+                animalAgeContains(age),
+                animalGenderContains(gender),
+                animalSizeContains(size)
+            )
+            .fetchOne();
+
+        return count == null ? 0 : count;
     }
 
     private BooleanExpression animalNameContains(String keyword) {

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.clova.anifriends.domain.animal.repository;
 
 import static com.clova.anifriends.domain.animal.QAnimal.animal;
-import static com.clova.anifriends.domain.recruitment.QRecruitment.recruitment;
 
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.AnimalAge;
@@ -149,15 +148,15 @@ public class AnimalRepositoryImpl implements AnimalRepositoryCustom {
         return new SliceImpl<>(animals, pageable, hasNext);
     }
 
-    private BooleanExpression cursorId(Long recruitmentId, LocalDateTime createdAt) {
-        if (recruitmentId == null || createdAt == null) {
+    private BooleanExpression cursorId(Long animalId, LocalDateTime createdAt) {
+        if (animalId == null || createdAt == null) {
             return null;
         }
 
-        return recruitment.createdAt.lt(createdAt)
+        return animal.createdAt.lt(createdAt)
             .or(
-                recruitment.recruitmentId.lt(recruitmentId)
-                    .and(recruitment.createdAt.eq(createdAt)
+                animal.animalId.lt(animalId)
+                    .and(animal.createdAt.eq(createdAt)
                     )
             );
     }

--- a/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
@@ -20,11 +20,13 @@ import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -97,6 +99,42 @@ public class AnimalService {
         );
 
         return FindAnimalsResponse.from(animalsWithPagination);
+    }
+
+    @Transactional(readOnly = true)
+    public FindAnimalsResponse findAnimalsByVolunteerV2(
+        AnimalType type,
+        AnimalActive active,
+        AnimalNeuteredFilter neuteredFilter,
+        AnimalAge age,
+        AnimalGender gender,
+        AnimalSize size,
+        LocalDateTime createdAt,
+        Long animalId,
+        Pageable pageable
+    ) {
+        Slice<Animal> animalsWithPagination = animalRepository.findAnimalsByVolunteerV2(
+            type,
+            active,
+            neuteredFilter,
+            age,
+            gender,
+            size,
+            createdAt,
+            animalId,
+            pageable
+        );
+
+        Long count = animalRepository.countAnimalsV2(
+            type,
+            active,
+            neuteredFilter,
+            age,
+            gender,
+            size
+        );
+
+        return FindAnimalsResponse.fromV2(animalsWithPagination, count);
     }
 
     @Transactional

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -79,14 +79,17 @@ public class RecruitmentRepositoryImpl implements
             .offset(pageable.getOffset())
             .fetch();
 
-        boolean hasNext = false;
+        boolean hasNext = hasNext(pageable.getPageSize(), content);
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
 
-        if (content.size() > pageable.getPageSize()) {
-            content.remove(pageable.getPageSize());
-            hasNext = true;
+    private boolean hasNext(int pageSize, List<Recruitment> recruitments) {
+        if (recruitments.size() <= pageSize) {
+            return false;
         }
 
-        return new SliceImpl<>(content, pageable, hasNext);
+        recruitments.remove(pageSize);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
### ⛏ 작업 사항
- 보호동물 목록 정렬 기준인 `created_at`과 보호 동물의 PK인 `animal_id` 기반으로 no offset 페이지네이션 레포지토리 구현
- V2의 dto, service, controller 생성
- repository, service, controller 테스트코드 작성

### 📝 작업 요약
- 보호동물 검색(봉사자) 로직의 페이지네이션을 커서 기반으로 개선했습니다.

### 💡 관련 이슈
- close #269 