### PR TITLE
refactor: 봉사 신청 로직 동시성 이슈를 해결한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
@@ -61,11 +61,12 @@ public class Applicant extends BaseTimeEntity {
         Volunteer volunteer
     ) {
         validateRecruitment(recruitment);
-        checkConcurrency(recruitment);
-        this.recruitment = recruitment;
-        recruitment.addApplicant(this);
         validateVolunteer(volunteer);
+        validateApplicantCount(recruitment);
+        recruitment.increaseApplicantCount();
+        this.recruitment = recruitment;
         this.volunteer = volunteer;
+        recruitment.addApplicant(this);
         volunteer.addApplicant(this);
     }
 
@@ -84,8 +85,8 @@ public class Applicant extends BaseTimeEntity {
         }
     }
 
-    private void checkConcurrency(Recruitment recruitment) {
-        if (recruitment.getApplicantCount() >= recruitment.getCapacity()) {
+    private void validateApplicantCount(Recruitment recruitment) {
+        if (recruitment.isFullApplicants()) {
             throw new ApplicantConflictException(ErrorCode.CONCURRENCY, "모집 인원이 초과되었습니다.");
         }
     }

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -18,9 +18,11 @@ import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
 import com.clova.anifriends.global.aspect.DataIntegrityHandler;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApplicantService {
@@ -32,11 +34,15 @@ public class ApplicantService {
     @Transactional
     @DataIntegrityHandler(message = "이미 신청한 봉사입니다.", exceptionClass = ApplicantConflictException.class)
     public void registerApplicant(Long recruitmentId, Long volunteerId) {
-        Recruitment recruitment = getRecruitment(recruitmentId);
+        Recruitment recruitmentPessimistic = getRecruitmentPessimistic(recruitmentId);
         Volunteer volunteer = getVolunteer(volunteerId);
-
-        Applicant applicant = new Applicant(recruitment, volunteer);
+        Applicant applicant = new Applicant(recruitmentPessimistic, volunteer);
         applicantRepository.save(applicant);
+    }
+
+    private Recruitment getRecruitmentPessimistic(Long recruitmentId) {
+        return recruitmentRepository.findByIdPessimistic(recruitmentId)
+            .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 봉사 모집글입니다."));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/clova/anifriends/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/Recruitment.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.recruitment;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.common.BaseTimeEntity;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentBadRequestException;
+import com.clova.anifriends.domain.recruitment.vo.RecruitmentApplicantCount;
 import com.clova.anifriends.domain.recruitment.vo.RecruitmentContent;
 import com.clova.anifriends.domain.recruitment.vo.RecruitmentInfo;
 import com.clova.anifriends.domain.recruitment.vo.RecruitmentTitle;
@@ -65,6 +66,8 @@ public class Recruitment extends BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    private RecruitmentApplicantCount applicantCount = new RecruitmentApplicantCount(0);
 
     public Recruitment(
         Shelter shelter,
@@ -157,6 +160,14 @@ public class Recruitment extends BaseTimeEntity {
         info.checkDeletable();
     }
 
+    public void increaseApplicantCount() {
+        this.applicantCount = this.applicantCount.increase();
+    }
+
+    public boolean isFullApplicants() {
+        return applicantCount.getApplicantCount() >= info.getCapacity();
+    }
+
     public Long getRecruitmentId() {
         return recruitmentId;
     }
@@ -189,6 +200,7 @@ public class Recruitment extends BaseTimeEntity {
         return info.getDeadline();
     }
 
+    @Override
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
@@ -208,7 +220,7 @@ public class Recruitment extends BaseTimeEntity {
     }
 
     public int getApplicantCount() {
-        return applicants.size();
+        return applicantCount.getApplicantCount();
     }
 
     public List<Applicant> getApplicants() {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,10 +1,12 @@
 package com.clova.anifriends.domain.recruitment.repository;
 
 import com.clova.anifriends.domain.recruitment.Recruitment;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +37,8 @@ public interface RecruitmentRepository
 
     @Query("select r, r.shelter.shelterId from Recruitment r where r.recruitmentId = :recruitmentId")
     Optional<Recruitment> findRecruitmentDetail(@Param("recruitmentId") Long recruitmentId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from Recruitment r where r.recruitmentId = :recruitmentId")
+    Optional<Recruitment> findByIdPessimistic(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -229,9 +229,4 @@ public class RecruitmentService {
         return recruitmentRepository.findByShelterIdAndRecruitmentId(shelterId, recruitmentId)
             .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 모집글입니다."));
     }
-
-    private Recruitment getRecruitmentById(long id) {
-        return recruitmentRepository.findById(id)
-            .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 모집글입니다."));
-    }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/vo/RecruitmentApplicantCount.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/vo/RecruitmentApplicantCount.java
@@ -1,0 +1,36 @@
+package com.clova.anifriends.domain.recruitment.vo;
+
+import com.clova.anifriends.domain.recruitment.exception.RecruitmentBadRequestException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.text.MessageFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecruitmentApplicantCount {
+
+    private static final int ZERO = 0;
+
+    @Column(name = "applicant_count")
+    private int applicantCount = 0;
+
+    public RecruitmentApplicantCount(int applicantCount) {
+        validateApplicantCount(applicantCount);
+        this.applicantCount = applicantCount;
+    }
+
+    private void validateApplicantCount(int applicantCount) {
+        if(applicantCount < ZERO) {
+            throw new RecruitmentBadRequestException(
+                MessageFormat.format("봉사 모집 신청자 수는 {0} 이상이어야 합니다.", ZERO));
+        }
+    }
+
+    public RecruitmentApplicantCount increase() {
+        return new RecruitmentApplicantCount(applicantCount + 1);
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantIntegrationTest.java
@@ -13,6 +13,11 @@ import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,16 +32,22 @@ public class ApplicantIntegrationTest extends BaseIntegrationTest {
     @DisplayName("registerApplicant 메서드 호출 시")
     class RegisterApplicantTest {
 
+        Shelter shelter;
+
+        @BeforeEach
+        void setUp() {
+            shelter = ShelterFixture.shelter();
+            shelterRepository.save(shelter);
+        }
+
         @Test
         @DisplayName("예외(ApplicantConflictException): 중복 봉사 신청")
         void exceptionWhenDuplicateApply() {
             // given
-            Shelter shelter = ShelterFixture.shelter();
             Volunteer volunteer = VolunteerFixture.volunteer();
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
             Applicant applicant = ApplicantFixture.applicant(recruitment, volunteer);
 
-            shelterRepository.save(shelter);
             volunteerRepository.save(volunteer);
             recruitmentRepository.save(recruitment);
             applicantRepository.save(applicant);
@@ -49,6 +60,85 @@ public class ApplicantIntegrationTest extends BaseIntegrationTest {
             // then
             assertThat(exception).isInstanceOf(ApplicantConflictException.class);
         }
-    }
 
+        @Test
+        @DisplayName("성공: 30명 정원, 30명 동시 신청")
+        void registerApplicantWhenRegisterWith30In30Capacity() throws InterruptedException {
+            //gvien
+            int capacity = 30;
+            List<Volunteer> volunteers = VolunteerFixture.volunteers(capacity);
+            Recruitment recruitment = RecruitmentFixture.recruitment(shelter, capacity);
+            volunteerRepository.saveAll(volunteers);
+            recruitmentRepository.save(recruitment);
+
+            int poolSize = 30;
+            ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
+            CountDownLatch latch = new CountDownLatch(poolSize);
+
+            //when
+            for (int i = 0; i < poolSize; i++) {
+                int finalI = i;
+                executorService.submit(() -> {
+                    try {
+                        applicantService.registerApplicant(shelter.getShelterId(),
+                            volunteers.get(finalI).getVolunteerId());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            //then
+            Recruitment findRecruitment = entityManager.find(Recruitment.class,
+                recruitment.getRecruitmentId());
+            List<Applicant> findApplicants = getApplicants(recruitment);
+            assertThat(findRecruitment.getApplicantCount()).isEqualTo(capacity);
+            assertThat(findApplicants).hasSize(capacity);
+        }
+
+        @Test
+        @DisplayName("성공: 10명 정원, 30명 동시 신청")
+        void registerApplicantWhenRegisterWith30In10Capacity() throws InterruptedException {
+            //gvien
+            int capacity = 10;
+            List<Volunteer> volunteers = VolunteerFixture.volunteers(capacity);
+            Recruitment recruitment = RecruitmentFixture.recruitment(shelter, capacity);
+            volunteerRepository.saveAll(volunteers);
+            recruitmentRepository.save(recruitment);
+
+            int poolSize = 30;
+            ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
+            CountDownLatch latch = new CountDownLatch(poolSize);
+
+            //when
+            for (int i = 0; i < poolSize; i++) {
+                int finalI = i;
+                executorService.submit(() -> {
+                    try {
+                        applicantService.registerApplicant(shelter.getShelterId(),
+                            volunteers.get(finalI).getVolunteerId());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            //then
+            Recruitment findRecruitment = entityManager.find(Recruitment.class,
+                recruitment.getRecruitmentId());
+            List<Applicant> findApplicants = getApplicants(recruitment);
+            assertThat(findRecruitment.getApplicantCount()).isEqualTo(capacity);
+            assertThat(findApplicants).hasSize(capacity);
+        }
+
+        private List<Applicant> getApplicants(Recruitment recruitment) {
+            return entityManager.createQuery(
+                    "select a from Applicant a where a.recruitment.recruitmentId = :recruitmentId",
+                    Applicant.class)
+                .setParameter("recruitmentId", recruitment.getRecruitmentId())
+                .getResultList();
+        }
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -87,7 +87,7 @@ class ApplicantServiceTest {
             setField(volunteer, "volunteerId", 1L);
             setField(recruitment, "recruitmentId", 1L);
             setField(recruitment, "info", recruitmentInfo);
-            given(recruitmentRepository.findById(anyLong())).willReturn(
+            given(recruitmentRepository.findByIdPessimistic(anyLong())).willReturn(
                 Optional.ofNullable(recruitment));
             given(volunteerRepository.findById(anyLong())).willReturn(
                 Optional.ofNullable(volunteer));
@@ -107,7 +107,7 @@ class ApplicantServiceTest {
             setField(volunteer, "volunteerId", 1L);
             setField(recruitment, "recruitmentId", 1L);
             setField(recruitment, "info", recruitmentInfo);
-            given(recruitmentRepository.findById(anyLong())).willReturn(
+            given(recruitmentRepository.findByIdPessimistic(anyLong())).willReturn(
                 Optional.ofNullable(recruitment));
             given(volunteerRepository.findById(anyLong())).willReturn(
                 Optional.ofNullable(volunteer));

--- a/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentFixture.java
@@ -31,6 +31,19 @@ public class RecruitmentFixture {
         );
     }
 
+    public static Recruitment recruitment(Shelter shelter, int capacity) {
+        return new Recruitment(
+            shelter,
+            RECRUITMENT_TITLE,
+            capacity,
+            RECRUITMENT_CONTENT,
+            START_TIME,
+            END_TIME,
+            DEADLINE,
+            IMAGE_URL_LIST
+        );
+    }
+
     public static Recruitment recruitmentWithImages(Shelter shelter, List<String> imageUrls) {
         return new Recruitment(
             shelter,

--- a/src/test/java/com/clova/anifriends/domain/recruitment/vo/RecruitmentApplicantCountTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/vo/RecruitmentApplicantCountTest.java
@@ -1,0 +1,67 @@
+package com.clova.anifriends.domain.recruitment.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.clova.anifriends.domain.recruitment.exception.RecruitmentBadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class RecruitmentApplicantCountTest {
+
+    @Nested
+    @DisplayName("RecruitmentApplicantCount 생성 시")
+    class NewRecruitmentApplicantCount {
+
+        @Test
+        @DisplayName("성공")
+        void newRecruitmentApplicantCount() {
+            //given
+            int applicantCount = 10;
+
+            //when
+            RecruitmentApplicantCount recruitmentApplicantCount = new RecruitmentApplicantCount(
+                applicantCount);
+
+            //then
+            assertThat(recruitmentApplicantCount.getApplicantCount()).isEqualTo(applicantCount);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"-2", "-1"})
+        @DisplayName("예외(RecruitmentBadRequestException): 0보다 작은 입력값")
+        void exceptionWhenLT0(String minus) {
+            //given
+            int applicantCountLT0 = Integer.parseInt(minus);
+
+            //when
+            Exception exception = catchException(
+                () -> new RecruitmentApplicantCount(applicantCountLT0));
+
+            //then
+            assertThat(exception).isInstanceOf(RecruitmentBadRequestException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("increase 메서드 호출 시")
+    class IncreaseTest {
+
+        @Test
+        @DisplayName("성공")
+        void increase() {
+            //given
+            RecruitmentApplicantCount applicantCount = new RecruitmentApplicantCount(10);
+
+            //when
+            RecruitmentApplicantCount updatedApplicantCount = applicantCount.increase();
+
+            //then
+            assertThat(updatedApplicantCount.getApplicantCount())
+                .isEqualTo(applicantCount.getApplicantCount() + 1);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사 신청 동시성 이슈 발생 지점에 비관적 락을 적용하였습니다.

### 📝 작업 요약
- `@Lock(LockModeType.PESSIMISTIC_WRITE)`을 적용하였습니다.

### 💡 관련 이슈
- close #271 
