### PR TITLE
chore: dev 서버에 docker-compose를 이용한 redis 환경을 설정한다.

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -2,7 +2,7 @@ name: cd-dev-docker
 
 on:
   push:
-    branches: [ "dev", "feat/#298" ]
+    branches: [ "dev" ]
 
 jobs:
   build:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -2,7 +2,7 @@ name: cd-dev-docker
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "dev", "feat/#298" ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     // DB
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     //RestDocs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -83,6 +84,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility'
+    testImplementation "org.testcontainers:testcontainers:1.19.0"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.0"
 
     // S3 AWS
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'

--- a/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
@@ -15,8 +15,11 @@ import com.clova.anifriends.domain.auth.LoginUser;
 import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -149,5 +153,23 @@ public class AnimalController {
         @PathVariable Long animalId) {
         animalService.deleteAnimal(shelterId, animalId);
         return ResponseEntity.noContent().build();
+    }
+
+    private final RedisTemplate<String, Integer> redisTemplate;
+
+    @PostMapping("/data")
+    public ResponseEntity<String> setRedisData(
+        @RequestBody(required = true) Map<String, String> map) throws Exception {
+
+        redisTemplate.opsForValue().set(map.get("key"), Integer.valueOf(map.get("value")));
+
+        return new ResponseEntity<>("정상 등록", HttpStatus.CREATED);
+    }
+
+    @GetMapping("/data")
+    public ResponseEntity<Integer> getRedisData(
+        @RequestParam(required = true) String key) {
+
+        return new ResponseEntity<>(redisTemplate.opsForValue().get(key), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
@@ -15,11 +15,8 @@ import com.clova.anifriends.domain.auth.LoginUser;
 import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,7 +26,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -153,23 +149,5 @@ public class AnimalController {
         @PathVariable Long animalId) {
         animalService.deleteAnimal(shelterId, animalId);
         return ResponseEntity.noContent().build();
-    }
-
-    private final RedisTemplate<String, Integer> redisTemplate;
-
-    @PostMapping("/data")
-    public ResponseEntity<String> setRedisData(
-        @RequestBody(required = true) Map<String, String> map) throws Exception {
-
-        redisTemplate.opsForValue().set(map.get("key"), Integer.valueOf(map.get("value")));
-
-        return new ResponseEntity<>("정상 등록", HttpStatus.CREATED);
-    }
-
-    @GetMapping("/data")
-    public ResponseEntity<Integer> getRedisData(
-        @RequestParam(required = true) String key) {
-
-        return new ResponseEntity<>(redisTemplate.opsForValue().get(key), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package com.clova.anifriends.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+//    @Bean
+//    public RedisTemplate<String, Integer> redisTemplate() {
+//        RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+//        redisTemplate.setConnectionFactory(redisConnectionFactory());
+//        return redisTemplate;
+//    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
@@ -1,19 +1,23 @@
 package com.clova.anifriends.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Bean
@@ -21,19 +25,12 @@ public class RedisConfig {
         return new LettuceConnectionFactory(host, port);
     }
 
-//    @Bean
-//    public RedisTemplate<String, Integer> redisTemplate() {
-//        RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
-//        redisTemplate.setKeySerializer(new StringRedisSerializer());
-//        redisTemplate.setValueSerializer(new StringRedisSerializer());
-//        redisTemplate.setConnectionFactory(redisConnectionFactory());
-//        return redisTemplate;
-//    }
-
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        return redisTemplate;
+    public RedisTemplate<String, Integer> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+        return template;
     }
 }

--- a/src/test/java/com/clova/anifriends/AnifriendsApplicationTests.java
+++ b/src/test/java/com/clova/anifriends/AnifriendsApplicationTests.java
@@ -10,15 +10,17 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("dev")
 class AnifriendsApplicationTests {
 
-	@BeforeAll
-	static void beforeAll() {
-		Properties properties = System.getProperties();
-		properties.setProperty("ACCESS_TOKEN_SECRET", "_4RNpxi%CB:eoO6a>j=#|*e#$Fp%%aX{dFi%.!Y(ZIy'UMuAt.9.;LxpWn2BZV*");
-		properties.setProperty("REFRESH_TOKEN_SECRET", "Tlolt.z[e$1yO!%Uc\"F*QH=uf0vp3U5s5{X5=g=*nDZ>BWMIKIf9nzd6et2.:Fb");
-	}
+    @BeforeAll
+    static void beforeAll() {
+        Properties properties = System.getProperties();
+        properties.setProperty("ACCESS_TOKEN_SECRET",
+            "_4RNpxi%CB:eoO6a>j=#|*e#$Fp%%aX{dFi%.!Y(ZIy'UMuAt.9.;LxpWn2BZV*");
+        properties.setProperty("REFRESH_TOKEN_SECRET",
+            "Tlolt.z[e$1yO!%Uc\"F*QH=uf0vp3U5s5{X5=g=*nDZ>BWMIKIf9nzd6et2.:Fb");
+    }
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseControllerTest.java
@@ -23,6 +23,7 @@ import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
 import com.clova.anifriends.domain.review.service.ReviewService;
 import com.clova.anifriends.domain.shelter.service.ShelterService;
 import com.clova.anifriends.domain.volunteer.service.VolunteerService;
+import com.clova.anifriends.global.config.RedisConfig;
 import com.clova.anifriends.global.config.SecurityConfig;
 import com.clova.anifriends.global.config.WebMvcConfig;
 import com.clova.anifriends.global.image.S3Service;
@@ -48,7 +49,8 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest
-@Import({SecurityConfig.class, WebMvcConfig.class, RestDocsConfig.class, WebMvcTestConfig.class})
+@Import({SecurityConfig.class, WebMvcConfig.class, RestDocsConfig.class, WebMvcTestConfig.class,
+    RedisConfig.class})
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class BaseControllerTest {
 

--- a/src/test/java/com/clova/anifriends/base/config/RedisTestContainerConfig.java
+++ b/src/test/java/com/clova/anifriends/base/config/RedisTestContainerConfig.java
@@ -1,0 +1,28 @@
+package com.clova.anifriends.base.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class RedisTestContainerConfig {
+
+    private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+    private static final int REDIS_PORT = 6379;
+    private static final GenericContainer REDIS_CONTAINER;
+
+    static {
+        REDIS_CONTAINER = new GenericContainer(REDIS_IMAGE)
+            .withExposedPorts(REDIS_PORT)
+            .withReuse(true);
+        REDIS_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(REDIS_PORT)
+            .toString());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,10 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+  data:
+    redis:
+      host: redis
+      port: 6379
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
### ⛏ 작업 사항
- build.gradle에 redis 설정 및 testContainer 추가
- dev, prod, local yml 파일에 redis 설정 추가
- EC2에서 POST, GET 테스트 API 검증 완료

[POST] http://{ip}/api/data
![image](https://github.com/Anifriends/Anifriends-Backend/assets/70627982/bbd1ef30-ee31-4d3c-91b7-b0a0ee563537)

[GET] http://{ip}/api/data?key=test
![image](https://github.com/Anifriends/Anifriends-Backend/assets/70627982/484af42f-f116-42f0-8a71-b768704f1302)

테스트 API는 검증 후 삭제했습니다.

- redis의 key, value 값에 따라 redisConfig 파일에 템플릿을 추가하고 사용하시면 됩니다.

### 📝 작업 요약
dev 서버에 docker-compose를 이용한 redis 환경 설정

### 💡 관련 이슈
- close #298 
