### PR TITLE
refactor: findRecruitmentDetail의 n+1 문제를 fetch join으로 해결한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -35,7 +35,7 @@ public interface RecruitmentRepository
     Optional<Recruitment> findByShelterIdAndRecruitmentIdWithImages(
         @Param("shelterId") Long shelterId, @Param("recruitmentId") Long recruitmentId);
 
-    @Query("select r, r.shelter.shelterId from Recruitment r where r.recruitmentId = :recruitmentId")
+    @Query("select r from Recruitment r left join fetch r.images where r.recruitmentId = :recruitmentId")
     Optional<Recruitment> findRecruitmentDetail(@Param("recruitmentId") Long recruitmentId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)


### PR DESCRIPTION
### ⛏ 작업 사항
- `recruitment`의 `findRecruitmentsByShelter, findShelterRecruitmentsByShelter, findRecruitmentDetail, findCompletedRecruitments, findRecruitments, findRecruitmentsV2` 함수를 확인한 결과 `findRecruitmentDetail`에서 N + 1 문제가 발생했습니다. 이를 fetch join으로 해결했습니다.

### 📝 작업 요약
- findRecruitmentDetail의 n+1 문제를 fetch join으로 해결

### 💡 관련 이슈
- #272 
