### PR TITLE
fix: 인증 필터 예외 핸들링을 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/auth/authentication/JwtAuthenticationProvider.java
+++ b/src/main/java/com/clova/anifriends/domain/auth/authentication/JwtAuthenticationProvider.java
@@ -4,12 +4,14 @@ import com.clova.anifriends.domain.auth.jwt.JwtProvider;
 import com.clova.anifriends.domain.auth.dto.response.CustomClaims;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationProvider {
@@ -17,9 +19,11 @@ public class JwtAuthenticationProvider {
     private final JwtProvider jwtProvider;
 
     public Authentication authenticate(String accessToken) {
+        log.debug("[Authentication] JWT 인증 프로세스 시작");
         CustomClaims claims = jwtProvider.parseAccessToken(accessToken);
         JwtAuthentication authentication = new JwtAuthentication(claims.memberId(), claims.role(), accessToken);
         List<GrantedAuthority> authorities = getAuthorities(claims.authorities());
+        log.debug("[Authentication] JWT 인증 프로세스 종료");
         return UsernamePasswordAuthenticationToken.authenticated(authentication, accessToken,
             authorities);
     }

--- a/src/main/java/com/clova/anifriends/global/security/jwt/JJwtProvider.java
+++ b/src/main/java/com/clova/anifriends/global/security/jwt/JJwtProvider.java
@@ -97,10 +97,10 @@ public class JJwtProvider implements JwtProvider {
             List<String> authorities = userRole.getAuthorities();
             return CustomClaims.of(userId, userRole, authorities);
         } catch (ExpiredJwtException ex) {
-            log.info("[EX] {}: 만료된 JWT입니다.", ex.getClass().getSimpleName());
+            log.info("[Ex] {} 만료된 JWT입니다.", ex.getClass().getSimpleName());
             throw new ExpiredAccessTokenException("만료된 액세스 토큰입니다.");
         } catch (JwtException ex) {
-            log.info("[EX] {}: 잘못된 JWT입니다.", ex.getClass().getSimpleName());
+            log.info("[Ex] {} 잘못된 JWT입니다.", ex.getClass().getSimpleName());
         }
         throw new InvalidJwtException("유효하지 않은 JWT입니다.");
     }
@@ -113,10 +113,10 @@ public class JJwtProvider implements JwtProvider {
             UserRole userRole = UserRole.valueOf(claims.get(ROLE, String.class));
             return createToken(userId, userRole);
         } catch (ExpiredJwtException ex) {
-            log.info("[EX] {}: 만료된 리프레시 토큰입니다.", ex.getClass().getSimpleName());
+            log.info("[EX] {} 만료된 리프레시 토큰입니다.", ex.getClass().getSimpleName());
             throw new ExpiredRefreshTokenException("만료된 리프레시 토큰입니다.");
         } catch (JwtException ex) {
-            log.info("[EX] {}: 잘못된 리프레시 토큰입니다.", ex.getClass().getSimpleName());
+            log.info("[EX] {} 잘못된 리프레시 토큰입니다.", ex.getClass().getSimpleName());
         }
         throw new InvalidJwtException("유효하지 않은 리프레시 토큰입니다.");
     }

--- a/src/main/java/com/clova/anifriends/global/web/filter/JwtAuthenticationExceptionHandler.java
+++ b/src/main/java/com/clova/anifriends/global/web/filter/JwtAuthenticationExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.clova.anifriends.global.web.filter;
+
+import com.clova.anifriends.domain.auth.exception.ExpiredAccessTokenException;
+import com.clova.anifriends.domain.auth.exception.InvalidJwtException;
+import com.clova.anifriends.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredAccessTokenException e) {
+            log.debug("[Authentication] JWT 인증 예외 핸들링. 만료된 JWT");
+            ErrorResponse errorResponse
+                = new ErrorResponse(e.getErrorCode(), "액세스 토큰이 만료되었습니다.");
+            setResponse(response, errorResponse);
+        } catch (InvalidJwtException e) {
+            log.debug("[Authentication] JWT 인증 예외 핸들링. 잘못된 JWT");
+            ErrorResponse errorResponse
+                = new ErrorResponse(e.getErrorCode(), "인증되지 않은 사용자의 요청입니다.");
+            setResponse(response, errorResponse);
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorResponse errorResponse)
+        throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/web/filter/JwtAuthenticationExceptionHandler.java
+++ b/src/main/java/com/clova/anifriends/global/web/filter/JwtAuthenticationExceptionHandler.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.global.web.filter;
 
 import com.clova.anifriends.domain.auth.exception.ExpiredAccessTokenException;
 import com.clova.anifriends.domain.auth.exception.InvalidJwtException;
+import com.clova.anifriends.global.exception.ErrorCode;
 import com.clova.anifriends.global.exception.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -31,12 +32,12 @@ public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
         } catch (ExpiredAccessTokenException e) {
             log.debug("[Authentication] JWT 인증 예외 핸들링. 만료된 JWT");
             ErrorResponse errorResponse
-                = new ErrorResponse(e.getErrorCode(), "액세스 토큰이 만료되었습니다.");
+                = new ErrorResponse(ErrorCode.ACCESS_TOKEN_EXPIRED.getValue(), "액세스 토큰이 만료되었습니다.");
             setResponse(response, errorResponse);
         } catch (InvalidJwtException e) {
             log.debug("[Authentication] JWT 인증 예외 핸들링. 잘못된 JWT");
             ErrorResponse errorResponse
-                = new ErrorResponse(e.getErrorCode(), "인증되지 않은 사용자의 요청입니다.");
+                = new ErrorResponse(ErrorCode.UN_AUTHENTICATION.getValue(), "인증되지 않은 사용자의 요청입니다.");
             setResponse(response, errorResponse);
         }
     }

--- a/src/main/java/com/clova/anifriends/global/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/clova/anifriends/global/web/filter/JwtAuthenticationFilter.java
@@ -11,9 +11,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilter {
 
@@ -24,11 +26,15 @@ public class JwtAuthenticationFilter extends GenericFilter {
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
         throws IOException, ServletException {
+        log.debug("[Authentication] JWT 인증 필터 시작");
         HttpServletRequest request = (HttpServletRequest) req;
         String bearerAccessToken = request.getHeader(HEADER);
         if (Objects.nonNull(bearerAccessToken)) {
+            log.debug("[Authentication] JWT={}", bearerAccessToken);
             String accessToken = removeBearer(bearerAccessToken);
             Authentication authentication = authenticationProvider.authenticate(accessToken);
+            log.debug("[Authentication] JWT 인증 필터 종료. 사용자 인증 성공. Authentication={}",
+                authentication);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         chain.doFilter(req, res);
@@ -41,6 +47,7 @@ public class JwtAuthenticationFilter extends GenericFilter {
 
     private void checkTokenContainsBearer(String bearerAccessToken) {
         if(!bearerAccessToken.contains(BEARER)) {
+            log.debug("[Authentication] JWT 인증 필터 종료. 사용자 인증 실패. Bearer 미포함");
             throw new InvalidJwtException("올바르지 않는 액세스 토큰 형식입니다.");
         }
     }

--- a/src/test/java/com/clova/anifriends/global/web/filter/JwtAuthenticationExceptionHandlerTest.java
+++ b/src/test/java/com/clova/anifriends/global/web/filter/JwtAuthenticationExceptionHandlerTest.java
@@ -1,0 +1,72 @@
+package com.clova.anifriends.global.web.filter;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.clova.anifriends.base.BaseControllerTest;
+import com.clova.anifriends.domain.auth.dto.response.TokenResponse;
+import com.clova.anifriends.domain.auth.jwt.UserRole;
+import com.clova.anifriends.domain.auth.support.AuthFixture;
+import com.clova.anifriends.global.exception.ErrorCode;
+import com.clova.anifriends.global.security.jwt.JJwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.ResultActions;
+
+class JwtAuthenticationExceptionHandlerTest extends BaseControllerTest {
+
+    @Nested
+    @DisplayName("JWT 필터 예외 발생 시")
+    class DoFilterInternalTest {
+
+        @Test
+        @DisplayName("성공: 올바른 형식의 토큰")
+        void doFilterInternal() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/api/shelters/recruitments")
+                .header(AUTHORIZATION, shelterAccessToken));
+
+            //then
+            resultActions.andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("성공(ExpiredAccessTokenException): 만료된 토큰 예외 핸들링")
+        void handleExpiredAccessTokenEx() throws Exception {
+            //given
+            JJwtProvider jJwtProvider = AuthFixture.jJwtProvider();
+            ReflectionTestUtils.setField(jJwtProvider, "expirySeconds", -1000);
+            TokenResponse token = jJwtProvider.createToken(1L, UserRole.ROLE_SHELTER);
+
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/api/shelters/recruitments")
+                .header(AUTHORIZATION, "Bearer " + token.accessToken()));
+
+            //then
+            resultActions.andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.ACCESS_TOKEN_EXPIRED.getValue()))
+                .andExpect(jsonPath("$.message").isString());
+        }
+
+        @ParameterizedTest
+        @CsvSource({"asdf", "Bearer ", "Bearer asdf"})
+        @DisplayName("성공(InvalidJwtException): 올바르지 않은 토큰 예외 핸들링")
+        void handleInvalidJwtEx(String invalidToken) throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/api/shelters/recruitments")
+                .header(AUTHORIZATION, invalidToken));
+
+            //then
+            resultActions.andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.UN_AUTHENTICATION.getValue()))
+                .andExpect(jsonPath("$.message").isString());
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- JWT 인증 필터에서 발생하는 예외 핸들링을 추가하였습니다.
- 필터에서 예외가 발생한는 경우 cors가 적용되지 않는 문제를 수정하였습니다.
  - cors 필터를 직접 추가하여 필터 순서를 변경하였습니다. cors 필터를 인증 필터와 인증 필터 예외 핸들러보다 앞단에 두어 항상 cors 필터를 거치도록 조정하였습니다.

### 📝 작업 요약
- JWT 인증 예외 핸들러 필터 추가
- cors 설정 변경

### 💡 관련 이슈
- close #302 
