### PR TITLE
refactor: 프로필 이미지 수정 시 null 대신 빈 문자열을 다루도록 개선한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/shelter/Shelter.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/Shelter.java
@@ -29,6 +29,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Shelter extends BaseTimeEntity {
 
+    private static final String BLANK = "";
+
     @Id
     @Column(name = "shelter_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -159,7 +161,7 @@ public class Shelter extends BaseTimeEntity {
     }
 
     public String getImage() {
-        return this.image == null ? null : this.image.getImageUrl();
+        return this.image == null ? BLANK : this.image.getImageUrl();
     }
 
     public String getDeviceToken() {

--- a/src/main/java/com/clova/anifriends/domain/shelter/Shelter.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/Shelter.java
@@ -90,13 +90,16 @@ public class Shelter extends BaseTimeEntity {
     }
 
     private ShelterImage updateImage(String imageUrl) {
-        if (nonNull(this.image) && this.image.isSameWith(imageUrl)) {
-            return this.image;
-        }
-        if (nonNull(imageUrl)) {
+        if(nonNull(imageUrl)) {
+            if(imageUrl.isBlank()) {
+                return null;
+            }
+            if(nonNull(image) && image.isSameWith(imageUrl)) {
+                return image;
+            }
             return new ShelterImage(this, imageUrl);
         }
-        return null;
+        return image;
     }
 
     public Optional<String> findImageToDelete(String newImageUrl) {

--- a/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
@@ -145,13 +145,16 @@ public class Volunteer extends BaseTimeEntity {
     }
 
     private VolunteerImage updateVolunteerImage(String imageUrl) {
-        if (Objects.nonNull(image) && image.isEqualImageUrl(imageUrl)) {
-            return this.image;
+        if(Objects.nonNull(imageUrl)) {
+            if(imageUrl.isBlank()) {
+                return null;
+            }
+            if (Objects.nonNull(image) && image.isSameWith(imageUrl)) {
+                return image;
+            }
+            return new VolunteerImage(this, imageUrl);
         }
-        if (Objects.isNull(imageUrl)) {
-            return null;
-        }
-        return new VolunteerImage(this, imageUrl);
+        return image;
     }
 
     public long getReviewCount() {

--- a/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
@@ -41,6 +41,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Volunteer extends BaseTimeEntity {
 
+    private static final String BLANK = "";
+
     @Id
     @Column(name = "volunteer_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -196,7 +198,7 @@ public class Volunteer extends BaseTimeEntity {
     }
 
     public String getVolunteerImageUrl() {
-        return this.image == null ? null : image.getImageUrl();
+        return this.image == null ? BLANK : image.getImageUrl();
     }
 
     public List<Applicant> getApplicants() {

--- a/src/main/java/com/clova/anifriends/domain/volunteer/VolunteerImage.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/VolunteerImage.java
@@ -53,7 +53,7 @@ public class VolunteerImage extends BaseTimeEntity {
         }
     }
 
-    public boolean isEqualImageUrl(String imageUrl) {
+    public boolean isSameWith(String imageUrl) {
         return this.imageUrl.equals(imageUrl);
     }
 

--- a/src/test/java/com/clova/anifriends/domain/shelter/ShelterTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/ShelterTest.java
@@ -184,7 +184,7 @@ class ShelterTest {
             );
 
             // then
-            assertThat(shelter.getImage()).isNull();
+            assertThat(shelter.getImage()).isBlank();
         }
 
         @Test
@@ -231,7 +231,7 @@ class ShelterTest {
             );
 
             // then
-            assertThat(shelter.getImage()).isNull();
+            assertThat(shelter.getImage()).isBlank();
         }
 
     }

--- a/src/test/java/com/clova/anifriends/domain/shelter/ShelterTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/ShelterTest.java
@@ -168,14 +168,14 @@ class ShelterTest {
         void updateExistToNone() {
             // given
             String originImageUrl = "originImageUrl";
-            String nullNewImageUrl = null;
+            String blankImageUrl = "";
 
             Shelter shelter = ShelterFixture.shelter(originImageUrl);
 
             // when
             shelter.updateShelter(
                 shelter.getName(),
-                nullNewImageUrl,
+                blankImageUrl,
                 shelter.getAddress(),
                 shelter.getAddressDetail(),
                 shelter.getPhoneNumber(),

--- a/src/test/java/com/clova/anifriends/domain/volunteer/VolunteerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/VolunteerTest.java
@@ -166,6 +166,25 @@ class VolunteerTest {
             //then
             assertThat(volunteer.getVolunteerImageUrl()).isEqualTo(notEqualsImageUrl);
         }
+
+        @Test
+        @DisplayName("성공: 이미지 url 입력값이 blank이고, 봉사자 이미지가 존재한다면 현재 이미지는 null이다.")
+        void updateVolunteerWhenImageUrlIsBlank() {
+            //given
+            String imageUrl = "asdf";
+            volunteer.updateVolunteerInfo(volunteer.getName(),
+                volunteer.getGender(), volunteer.getBirthDate(), volunteer.getPhoneNumber(),
+                imageUrl);
+            String blankImageUrl = "";
+
+            //when
+            volunteer.updateVolunteerInfo(
+                volunteer.getName(), volunteer.getGender(), volunteer.getBirthDate(),
+                volunteer.getPhoneNumber(), blankImageUrl);
+
+            //then
+            assertThat(volunteer.getVolunteerImageUrl()).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/clova/anifriends/domain/volunteer/VolunteerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/VolunteerTest.java
@@ -100,7 +100,7 @@ class VolunteerTest {
         }
 
         @Test
-        @DisplayName("성공: 이미지 url 입력값이 null이고, 봉사자 이미지가 null인 경우 현재 이미지는 null이다.")
+        @DisplayName("성공: 이미지 url 입력값이 null이고, 봉사자 이미지가 null인 경우 현재 이미지는 공백이다.")
         void updateVolunteerNullImage() {
             //given
             String nullImageUrl = null;
@@ -110,7 +110,7 @@ class VolunteerTest {
                 volunteer.getBirthDate(), volunteer.getPhoneNumber(), nullImageUrl);
 
             //then
-            assertThat(volunteer.getVolunteerImageUrl()).isNull();
+            assertThat(volunteer.getVolunteerImageUrl()).isBlank();
         }
 
         @Test
@@ -168,7 +168,7 @@ class VolunteerTest {
         }
 
         @Test
-        @DisplayName("성공: 이미지 url 입력값이 blank이고, 봉사자 이미지가 존재한다면 현재 이미지는 null이다.")
+        @DisplayName("성공: 이미지 url 입력값이 공백이고, 봉사자 이미지가 존재한다면 현재 이미지는 공백이다.")
         void updateVolunteerWhenImageUrlIsBlank() {
             //given
             String imageUrl = "asdf";
@@ -183,7 +183,7 @@ class VolunteerTest {
                 volunteer.getPhoneNumber(), blankImageUrl);
 
             //then
-            assertThat(volunteer.getVolunteerImageUrl()).isNull();
+            assertThat(volunteer.getVolunteerImageUrl()).isBlank();
         }
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자, 보호소 프로필 이미지 수정 시 빈 문자열을 다루도록 개선하였습니다.
  - imageUrl 반환 시 null 인 경우 null 대신 빈 문자열을 다루도록 개선하였습니다.
  - 이미지 업데이트 시 null 이 입력된 경우 무시하고, 빈 문자열이 입력된 경우 기존 이미지를 삭제합니다.

### 📝 작업 요약
- 봉사자, 보호소 이미지 업데이트 및 반환 로직 수정

### 💡 관련 이슈
- close #301 
