### PR TITLE
feat: 리소스 생성시 응답 바디에 리소스 ID를 함께 반환하도록 변경한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
@@ -37,13 +37,13 @@ public class AnimalController {
 
     @ShelterOnly
     @PostMapping("/shelters/animals")
-    public ResponseEntity<Void> registerAnimal(
+    public ResponseEntity<RegisterAnimalResponse> registerAnimal(
         @LoginUser Long volunteerId,
         @RequestBody @Valid RegisterAnimalRequest registerAnimalRequest) {
         RegisterAnimalResponse registerAnimalResponse = animalService.registerAnimal(volunteerId,
             registerAnimalRequest);
         URI location = URI.create("/api/shelters/animals/" + registerAnimalResponse.animalId());
-        return ResponseEntity.created(location).build();
+        return ResponseEntity.created(location).body(registerAnimalResponse);
     }
 
     @GetMapping("/animals/{animalId}")

--- a/src/main/java/com/clova/anifriends/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/controller/ChatRoomController.java
@@ -1,16 +1,17 @@
 package com.clova.anifriends.domain.chat.controller;
 
 import com.clova.anifriends.domain.auth.LoginUser;
+import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
+import com.clova.anifriends.domain.auth.authorization.UserOnly;
+import com.clova.anifriends.domain.auth.authorization.VolunteerOnly;
 import com.clova.anifriends.domain.chat.dto.request.RegisterChatRoomRequest;
 import com.clova.anifriends.domain.chat.dto.response.FindChatMessagesResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomDetailResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomIdResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomsResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindUnreadCountResponse;
+import com.clova.anifriends.domain.chat.dto.response.RegisterChatRoomResponse;
 import com.clova.anifriends.domain.chat.service.ChatRoomService;
-import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
-import com.clova.anifriends.domain.auth.authorization.UserOnly;
-import com.clova.anifriends.domain.auth.authorization.VolunteerOnly;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -66,15 +68,16 @@ public class ChatRoomController {
 
     @VolunteerOnly
     @PostMapping("/volunteers/chat/rooms")
-    public ResponseEntity<Void> registerChatRoom(
+    public ResponseEntity<RegisterChatRoomResponse> registerChatRoom(
         @LoginUser Long volunteerId,
-        RegisterChatRoomRequest registerChatRoomRequest
+        @RequestBody RegisterChatRoomRequest registerChatRoomRequest
     ) {
-        long chatRoomId = chatRoomService.registerChatRoom(volunteerId,
+        RegisterChatRoomResponse registerChatRoomResponse = chatRoomService.registerChatRoom(
+            volunteerId,
             registerChatRoomRequest.shelterId());
-
-        URI location = URI.create("/api/volunteers/chat/rooms/" + chatRoomId);
-        return ResponseEntity.created(location).build();
+        URI location
+            = URI.create("/api/volunteers/chat/rooms/" + registerChatRoomResponse.chatRoomId());
+        return ResponseEntity.created(location).body(registerChatRoomResponse);
     }
 
     @VolunteerOnly

--- a/src/main/java/com/clova/anifriends/domain/chat/dto/response/RegisterChatRoomResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/dto/response/RegisterChatRoomResponse.java
@@ -1,0 +1,10 @@
+package com.clova.anifriends.domain.chat.dto.response;
+
+import com.clova.anifriends.domain.chat.ChatRoom;
+
+public record RegisterChatRoomResponse(Long chatRoomId) {
+
+    public static RegisterChatRoomResponse from(ChatRoom chatRoom) {
+        return new RegisterChatRoomResponse(chatRoom.getChatRoomId());
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clova/anifriends/domain/chat/service/ChatRoomService.java
@@ -8,6 +8,7 @@ import com.clova.anifriends.domain.chat.dto.response.FindChatRoomDetailResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomIdResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomsResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindUnreadCountResponse;
+import com.clova.anifriends.domain.chat.dto.response.RegisterChatRoomResponse;
 import com.clova.anifriends.domain.chat.exception.ChatNotFoundException;
 import com.clova.anifriends.domain.chat.exception.ChatRoomConflictException;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
@@ -52,13 +53,12 @@ public class ChatRoomService {
 
     @Transactional
     @DataIntegrityHandler(message = "이미 존재하는 채팅방입니다.", exceptionClass = ChatRoomConflictException.class)
-    public Long registerChatRoom(Long volunteerId, Long shelterId) {
+    public RegisterChatRoomResponse registerChatRoom(Long volunteerId, Long shelterId) {
         Volunteer volunteer = getVolunteer(volunteerId);
         Shelter shelter = getShelter(shelterId);
-
         ChatRoom chatRoom = new ChatRoom(volunteer, shelter);
         chatRoomRepository.save(chatRoom);
-        return chatRoom.getChatRoomId();
+        return RegisterChatRoomResponse.from(chatRoom);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentController.java
@@ -41,7 +41,8 @@ public class RecruitmentController {
     public ResponseEntity<RegisterRecruitmentResponse> registerRecruitment(
         @LoginUser Long volunteerId,
         @RequestBody @Valid RegisterRecruitmentRequest registerRecruitmentRequest) {
-        RegisterRecruitmentResponse response = recruitmentService.registerRecruitment(
+        RegisterRecruitmentResponse registerRecruitmentResponse
+            = recruitmentService.registerRecruitment(
             volunteerId,
             registerRecruitmentRequest.title(),
             registerRecruitmentRequest.startTime(),
@@ -50,8 +51,9 @@ public class RecruitmentController {
             registerRecruitmentRequest.capacity(),
             registerRecruitmentRequest.content(),
             registerRecruitmentRequest.imageUrls());
-        URI location = URI.create("/api/recruitments/" + response.recruitmentId());
-        return ResponseEntity.created(location).build();
+        URI location
+            = URI.create("/api/recruitments/" + registerRecruitmentResponse.recruitmentId());
+        return ResponseEntity.created(location).body(registerRecruitmentResponse);
     }
 
     @GetMapping("/recruitments/{recruitmentId}")

--- a/src/main/java/com/clova/anifriends/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/clova/anifriends/domain/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.clova.anifriends.domain.review.dto.response.FindReviewResponse;
 import com.clova.anifriends.domain.review.dto.response.FindShelterReviewsResponse;
 import com.clova.anifriends.domain.review.dto.response.FindShelterReviewsByShelterResponse;
 import com.clova.anifriends.domain.review.dto.response.FindVolunteerReviewsResponse;
+import com.clova.anifriends.domain.review.dto.response.RegisterReviewResponse;
 import com.clova.anifriends.domain.review.service.ReviewService;
 import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import com.clova.anifriends.domain.auth.authorization.VolunteerOnly;
@@ -42,14 +43,17 @@ public class ReviewController {
 
     @VolunteerOnly
     @PostMapping("/volunteers/reviews")
-    public ResponseEntity<Void> registerReview(
-        @LoginUser Long userId,
+    public ResponseEntity<RegisterReviewResponse> registerReview(
+        @LoginUser Long volunteerId,
         @RequestBody RegisterReviewRequest request
     ) {
-        long reviewId = reviewService.registerReview(userId, request.applicationId(),
-            request.content(), request.imageUrls());
-        URI location = URI.create("/api/volunteers/reviews/" + reviewId);
-        return ResponseEntity.created(location).build();
+        RegisterReviewResponse registerReviewResponse = reviewService.registerReview(
+            volunteerId,
+            request.applicationId(),
+            request.content(),
+            request.imageUrls());
+        URI location = URI.create("/api/volunteers/reviews/" + registerReviewResponse.reviewId());
+        return ResponseEntity.created(location).body(registerReviewResponse);
     }
 
     @ShelterOnly

--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/RegisterReviewResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/RegisterReviewResponse.java
@@ -1,0 +1,11 @@
+package com.clova.anifriends.domain.review.dto.response;
+
+import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
+import com.clova.anifriends.domain.review.Review;
+
+public record RegisterReviewResponse(Long reviewId) {
+
+    public static RegisterReviewResponse from(Review review) {
+        return new RegisterReviewResponse(review.getReviewId());
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/review/service/ReviewService.java
+++ b/src/main/java/com/clova/anifriends/domain/review/service/ReviewService.java
@@ -9,6 +9,7 @@ import com.clova.anifriends.domain.review.dto.response.FindReviewResponse;
 import com.clova.anifriends.domain.review.dto.response.FindShelterReviewsByShelterResponse;
 import com.clova.anifriends.domain.review.dto.response.FindShelterReviewsResponse;
 import com.clova.anifriends.domain.review.dto.response.FindVolunteerReviewsResponse;
+import com.clova.anifriends.domain.review.dto.response.RegisterReviewResponse;
 import com.clova.anifriends.domain.review.exception.ApplicantNotFoundException;
 import com.clova.anifriends.domain.review.exception.ReviewConflictException;
 import com.clova.anifriends.domain.review.exception.ReviewNotFoundException;
@@ -47,13 +48,13 @@ public class ReviewService {
 
     @Transactional
     @DataIntegrityHandler(message = "이미 작성한 리뷰가 존재합니다.", exceptionClass = ReviewConflictException.class)
-    public Long registerReview(Long userId, Long applicationId, String content,
+    public RegisterReviewResponse registerReview(Long userId, Long applicationId, String content,
         List<String> imageUrls) {
         Applicant applicant = getApplicant(userId, applicationId);
 
         Review review = new Review(applicant, content, imageUrls);
         reviewRepository.save(review);
-        return review.getReviewId();
+        return RegisterReviewResponse.from(review);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/controller/ShelterController.java
@@ -10,6 +10,7 @@ import com.clova.anifriends.domain.shelter.dto.response.CheckDuplicateShelterRes
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterSimpleResponse;
+import com.clova.anifriends.domain.shelter.dto.response.RegisterShelterResponse;
 import com.clova.anifriends.domain.shelter.service.ShelterService;
 import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import jakarta.validation.Valid;
@@ -40,9 +41,9 @@ public class ShelterController {
     }
 
     @PostMapping("/shelters")
-    public ResponseEntity<Void> registerShelter(
+    public ResponseEntity<RegisterShelterResponse> registerShelter(
         @RequestBody @Valid RegisterShelterRequest registerShelterRequest) {
-        Long shelterId = shelterService.registerShelter(
+        RegisterShelterResponse registerShelterResponse = shelterService.registerShelter(
             registerShelterRequest.email(),
             registerShelterRequest.password(),
             registerShelterRequest.name(),
@@ -51,8 +52,8 @@ public class ShelterController {
             registerShelterRequest.phoneNumber(),
             registerShelterRequest.sparePhoneNumber(),
             registerShelterRequest.isOpenedAddress());
-        URI location = URI.create("/api/shelters/" + shelterId);
-        return ResponseEntity.created(location).build();
+        URI location = URI.create("/api/shelters/" + registerShelterResponse.shelterId());
+        return ResponseEntity.created(location).body(registerShelterResponse);
     }
 
     @GetMapping("/shelters/{shelterId}/profile")

--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/response/RegisterShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/response/RegisterShelterResponse.java
@@ -1,0 +1,10 @@
+package com.clova.anifriends.domain.shelter.dto.response;
+
+import com.clova.anifriends.domain.shelter.Shelter;
+
+public record RegisterShelterResponse(Long shelterId) {
+
+    public static RegisterShelterResponse from(Shelter shelter) {
+        return new RegisterShelterResponse(shelter.getShelterId());
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/service/ShelterService.java
@@ -7,6 +7,7 @@ import com.clova.anifriends.domain.shelter.dto.response.CheckDuplicateShelterRes
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterSimpleResponse;
+import com.clova.anifriends.domain.shelter.dto.response.RegisterShelterResponse;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.shelter.vo.ShelterEmail;
@@ -25,7 +26,7 @@ public class ShelterService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
-    public Long registerShelter(
+    public RegisterShelterResponse registerShelter(
         String email,
         String password,
         String name,
@@ -45,7 +46,7 @@ public class ShelterService {
             isOpenedAddress,
             passwordEncoder);
         shelterRepository.save(shelter);
-        return shelter.getShelterId();
+        return RegisterShelterResponse.from(shelter);
     }
 
     @Transactional

--- a/src/main/java/com/clova/anifriends/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/controller/VolunteerController.java
@@ -8,6 +8,7 @@ import com.clova.anifriends.domain.volunteer.dto.request.UpdateVolunteerPassword
 import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
+import com.clova.anifriends.domain.volunteer.dto.response.RegisterVolunteerResponse;
 import com.clova.anifriends.domain.volunteer.service.VolunteerService;
 import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import com.clova.anifriends.domain.auth.authorization.VolunteerOnly;
@@ -41,10 +42,10 @@ public class VolunteerController {
     }
 
     @PostMapping("/volunteers")
-    public ResponseEntity<Void> registerVolunteer(
+    public ResponseEntity<RegisterVolunteerResponse> registerVolunteer(
         @RequestBody @Valid RegisterVolunteerRequest registerVolunteerRequest
     ) {
-        Long registeredVolunteerID = volunteerService.registerVolunteer(
+        RegisterVolunteerResponse registerVolunteerResponse = volunteerService.registerVolunteer(
             registerVolunteerRequest.email(),
             registerVolunteerRequest.password(),
             registerVolunteerRequest.name(),
@@ -52,8 +53,8 @@ public class VolunteerController {
             registerVolunteerRequest.phoneNumber(),
             registerVolunteerRequest.gender()
         );
-        URI location = URI.create(BASE_URI + registeredVolunteerID);
-        return ResponseEntity.created(location).build();
+        URI location = URI.create(BASE_URI + registerVolunteerResponse.volunteerId());
+        return ResponseEntity.created(location).body(registerVolunteerResponse);
     }
 
     @VolunteerOnly

--- a/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/RegisterVolunteerResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/RegisterVolunteerResponse.java
@@ -1,0 +1,10 @@
+package com.clova.anifriends.domain.volunteer.dto.response;
+
+import com.clova.anifriends.domain.volunteer.Volunteer;
+
+public record RegisterVolunteerResponse(Long volunteerId) {
+
+    public static RegisterVolunteerResponse from(Volunteer volunteer) {
+        return new RegisterVolunteerResponse(volunteer.getVolunteerId());
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/service/VolunteerService.java
@@ -6,6 +6,7 @@ import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
+import com.clova.anifriends.domain.volunteer.dto.response.RegisterVolunteerResponse;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerNotFoundException;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerEmail;
@@ -32,7 +33,7 @@ public class VolunteerService {
     }
 
     @Transactional
-    public Long registerVolunteer(
+    public RegisterVolunteerResponse registerVolunteer(
         String email,
         String password,
         String name,
@@ -43,7 +44,7 @@ public class VolunteerService {
         Volunteer volunteer = new Volunteer(email, password, birthDate, phoneNumber, gender, name,
             passwordEncoder);
         volunteerRepository.save(volunteer);
-        return volunteer.getVolunteerId();
+        return RegisterVolunteerResponse.from(volunteer);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/clova/anifriends/domain/animal/controller/AnimalControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/controller/AnimalControllerTest.java
@@ -110,6 +110,9 @@ class AnimalControllerTest extends BaseControllerTest {
                 ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 리소스에 접근 가능한 api")
+                ),
+                responseFields(
+                    fieldWithPath("animalId").type(NUMBER).description("생성된 보호 동물 ID")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/controller/ChatRoomControllerTest.java
@@ -29,6 +29,7 @@ import com.clova.anifriends.domain.chat.dto.response.FindChatRoomIdResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomsResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindChatRoomsResponse.FindChatRoomResponse;
 import com.clova.anifriends.domain.chat.dto.response.FindUnreadCountResponse;
+import com.clova.anifriends.domain.chat.dto.response.RegisterChatRoomResponse;
 import com.clova.anifriends.domain.chat.support.ChatRoomFixture;
 import com.clova.anifriends.domain.common.PageInfo;
 import com.clova.anifriends.domain.shelter.Shelter;
@@ -130,18 +131,13 @@ class ChatRoomControllerTest extends BaseControllerTest {
     @DisplayName("성공: 채팅방 생성 api 호출")
     void registerChatRoom() throws Exception {
         // given
-        Volunteer volunteer = VolunteerFixture.volunteer();
-        ReflectionTestUtils.setField(volunteer, "volunteerId", 1L);
-        Shelter shelter = ShelterFixture.shelter();
-        ReflectionTestUtils.setField(shelter, "shelterId", 1L);
-
-        RegisterChatRoomRequest request = new RegisterChatRoomRequest(
-            shelter.getShelterId());
-
+        RegisterChatRoomRequest request = new RegisterChatRoomRequest(1L);
         long chatRoomId = 1;
+        RegisterChatRoomResponse registerChatRoomResponse = new RegisterChatRoomResponse(
+            chatRoomId);
 
-        when(chatRoomService.registerChatRoom(volunteer.getVolunteerId(), shelter.getShelterId()))
-            .thenReturn(chatRoomId);
+        given(chatRoomService.registerChatRoom(anyLong(), anyLong()))
+            .willReturn(registerChatRoomResponse);
 
         // when
         ResultActions result = mockMvc.perform(post("/api/volunteers/chat/rooms")
@@ -160,6 +156,9 @@ class ChatRoomControllerTest extends BaseControllerTest {
                 ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 채팅방의 URI")
+                ),
+                responseFields(
+                    fieldWithPath("chatRoomId").description("생성된 채팅방 ID")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -115,6 +115,9 @@ class RecruitmentControllerTest extends BaseControllerTest {
                 ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 리소스에 대한 접근 api")
+                ),
+                responseFields(
+                    fieldWithPath("recruitmentId").type(NUMBER).description("생성된 봉사 모집글 ID")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
@@ -47,6 +47,7 @@ import com.clova.anifriends.domain.review.dto.response.FindReviewResponse;
 import com.clova.anifriends.domain.review.dto.response.FindShelterReviewsByShelterResponse;
 import com.clova.anifriends.domain.review.dto.response.FindShelterReviewsResponse;
 import com.clova.anifriends.domain.review.dto.response.FindVolunteerReviewsResponse;
+import com.clova.anifriends.domain.review.dto.response.RegisterReviewResponse;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import java.time.LocalDateTime;
@@ -161,15 +162,17 @@ class ReviewControllerTest extends BaseControllerTest {
     @DisplayName("성공: 리뷰 등록 api 호출")
     void registerReview() throws Exception {
         //given
+        long reviewId = 1L;
         Applicant applicant = applicant(recruitment(shelter()), volunteer(), ATTENDANCE);
         ReflectionTestUtils.setField(applicant, "applicantId", 1L);
         Review review = review(applicant);
-        ReflectionTestUtils.setField(review, "reviewId", 1L);
+        ReflectionTestUtils.setField(review, "reviewId", reviewId);
         RegisterReviewRequest request = registerReviewRequest(review(applicant));
+        RegisterReviewResponse registerReviewResponse = new RegisterReviewResponse(reviewId);
 
         when(reviewService.registerReview(anyLong(), eq(applicant.getApplicantId()),
             eq(review.getContent()), eq(review.getImages())))
-            .thenReturn(review.getReviewId());
+            .thenReturn(registerReviewResponse);
 
         //when
         ResultActions result = mockMvc.perform(
@@ -195,6 +198,9 @@ class ReviewControllerTest extends BaseControllerTest {
                 ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 리소스에 대한 접근 api")
+                ),
+                responseFields(
+                    fieldWithPath("reviewId").type(NUMBER).description("생성된 리뷰 ID")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
@@ -31,6 +31,7 @@ import com.clova.anifriends.domain.shelter.dto.response.CheckDuplicateShelterRes
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterDetailResponse;
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterMyPageResponse;
 import com.clova.anifriends.domain.shelter.dto.response.FindShelterSimpleResponse;
+import com.clova.anifriends.domain.shelter.dto.response.RegisterShelterResponse;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -85,10 +86,11 @@ class ShelterControllerTest extends BaseControllerTest {
         boolean isOpenedAddress = false;
         RegisterShelterRequest registerShelterRequest = new RegisterShelterRequest(email, password,
             name, address, addressDetail, phoneNumber, sparePhoneNumber, isOpenedAddress);
+        RegisterShelterResponse registerShelterResponse = new RegisterShelterResponse(1L);
 
         given(shelterService.registerShelter(anyString(), anyString(), anyString(), anyString(),
             anyString(), anyString(), anyString(), anyBoolean()))
-            .willReturn(1L);
+            .willReturn(registerShelterResponse);
 
         //when
         ResultActions resultActions = mockMvc.perform(post("/api/shelters")
@@ -120,8 +122,12 @@ class ShelterControllerTest extends BaseControllerTest {
                 ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 리소스 접근 가능 위치")
+                ),
+                responseFields(
+                    fieldWithPath("shelterId").type(JsonFieldType.NUMBER).description("생성된 보호소 ID")
                 )
             ));
+
     }
 
     @Test

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.dto.response.RegisterShelterResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,17 +36,19 @@ public class ShelterIntegrationTest extends BaseIntegrationTest {
             String sparePhoneNumber = "010-1234-1234";
             boolean isOpenedAddress = true;
 
-            Long registeredShelterId
-                = shelterService.registerShelter(email, oldRawPassword, shelterName, address,
+            RegisterShelterResponse registerShelterResponse = shelterService.registerShelter(email,
+                oldRawPassword, shelterName, address,
                 addressDetail, phoneNumber, sparePhoneNumber, isOpenedAddress);
             String newRawPassword = oldRawPassword + "a";
 
 
             //when
-            shelterService.updatePassword(registeredShelterId, oldRawPassword, newRawPassword);
+            shelterService.updatePassword(registerShelterResponse.shelterId(), oldRawPassword,
+                newRawPassword);
 
             //then
-            Shelter findShelter = entityManager.find(Shelter.class, registeredShelterId);
+            Shelter findShelter
+                = entityManager.find(Shelter.class, registerShelterResponse.shelterId());
             boolean isPasswordUpdated
                 = passwordEncoder.matchesPassword(newRawPassword, findShelter.getPassword());
             assertThat(isPasswordUpdated).isTrue();

--- a/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/controller/VolunteerControllerTest.java
@@ -30,6 +30,7 @@ import com.clova.anifriends.domain.volunteer.dto.request.UpdateVolunteerPassword
 import com.clova.anifriends.domain.volunteer.dto.response.CheckDuplicateVolunteerEmailResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerMyPageResponse;
 import com.clova.anifriends.domain.volunteer.dto.response.FindVolunteerProfileResponse;
+import com.clova.anifriends.domain.volunteer.dto.response.RegisterVolunteerResponse;
 import com.clova.anifriends.domain.volunteer.support.VolunteerDtoFixture;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerGender;
@@ -78,8 +79,9 @@ class VolunteerControllerTest extends BaseControllerTest {
     void registerVolunteer() throws Exception {
         // given
         RegisterVolunteerRequest registerVolunteerRequest = VolunteerDtoFixture.registerVolunteerRequest();
+        RegisterVolunteerResponse registerVolunteerResponse = new RegisterVolunteerResponse(1L);
         given(volunteerService.registerVolunteer(any(), any(), any(), any(), any(),
-            any())).willReturn(1L);
+            any())).willReturn(registerVolunteerResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -100,6 +102,9 @@ class VolunteerControllerTest extends BaseControllerTest {
                 ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 리소스 위치")
+                ),
+                responseFields(
+                    fieldWithPath("volunteerId").type(NUMBER).description("생성된 봉사자 ID")
                 )
             ));
     }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
+import com.clova.anifriends.domain.volunteer.dto.response.RegisterVolunteerResponse;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerGender;
 import java.time.LocalDate;
@@ -35,7 +36,7 @@ public class VolunteerIntegrationTest extends BaseIntegrationTest {
         @BeforeEach
         void setUp() {
             volunteer = VolunteerFixture.volunteer();
-            givenVolunteerId = volunteerService.registerVolunteer(
+            RegisterVolunteerResponse registerVolunteerResponse = volunteerService.registerVolunteer(
                 volunteer.getEmail(),
                 volunteer.getPassword(),
                 volunteer.getName(),
@@ -43,6 +44,7 @@ public class VolunteerIntegrationTest extends BaseIntegrationTest {
                 volunteer.getPhoneNumber(),
                 volunteer.getGender().toString()
             );
+            givenVolunteerId = registerVolunteerResponse.volunteerId();
         }
 
         @Test


### PR DESCRIPTION
### ⛏ 작업 사항
- 프론트엔드 요청에 따라 리소스 생성시 응답 메시지 바디에 리소스 ID를 반환하도록 변경하였습니다. 
  - 봉사 모집글, 보호 동물, 리뷰, 채팅방, 봉사자, 보호소에 대하여 추가했습니다.

### 📝 작업 요약
- 201 create 응답에 대해 응답 메시지 바디에 생성된 리소스 ID 추가

### 💡 관련 이슈
- close #310 
