### PR TITLE
refactor: 봉사자 입장에서 모집글 검색 시 count를 캐시에 저장한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -55,7 +55,7 @@ public class RecruitmentRepositoryImpl implements
                 recruitmentStartTimeGoe(startDate),
                 recruitmentStartTimeLoe(endDate)
             ).fetchOne();
-        return new PageImpl<>(content, pageable, count);
+        return new PageImpl<>(content, pageable, count != null ? count : 0);
     }
 
     @Override

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -14,6 +14,7 @@ public class RecruitmentCacheService {
     private final RecruitmentRepository recruitmentRepository;
 
     private static final Long RECRUITMENT_COUNT_NO_CACHE = -1L;
+    private static final Long COUNT_ONE = 1L;
 
     public Long getRecruitmentCount(
         String cacheKey
@@ -41,7 +42,21 @@ public class RecruitmentCacheService {
         Long cachedCount = redisTemplate.opsForValue().get(cacheKey);
 
         if (Objects.nonNull(cachedCount)) {
-            registerRecruitmentCount(cacheKey, cachedCount + 1L);
+            registerRecruitmentCount(cacheKey, cachedCount + COUNT_ONE);
+        }
+
+        long dbRecruitmentCount = recruitmentRepository.count();
+
+        registerRecruitmentCount(cacheKey, dbRecruitmentCount);
+    }
+
+    public void minusOneToRecruitmentCount(
+        String cacheKey
+    ) {
+        Long cachedCount = redisTemplate.opsForValue().get(cacheKey);
+
+        if (Objects.nonNull(cachedCount)) {
+            registerRecruitmentCount(cacheKey, cachedCount - COUNT_ONE);
         }
 
         long dbRecruitmentCount = recruitmentRepository.count();

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -23,9 +23,9 @@ public class RecruitmentCacheService {
 
         if (Objects.isNull(cachedCount)) {
             return RECRUITMENT_COUNT_NO_CACHE;
+        } else {
+            return ((Integer) cachedCount).longValue();
         }
-
-        return ((Integer) cachedCount).longValue();
     }
 
     public void registerRecruitmentCount(

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -23,6 +23,10 @@ public class RecruitmentCacheService {
 
         if (Objects.isNull(cachedCount)) {
             return RECRUITMENT_COUNT_NO_CACHE;
+        }
+
+        if (cachedCount instanceof Long) {
+            return (Long) cachedCount;
         } else {
             return ((Integer) cachedCount).longValue();
         }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -20,12 +20,11 @@ public class RecruitmentCacheService {
         String cacheKey
     ) {
         Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
+
         if (Objects.isNull(cachedCount)) {
             return RECRUITMENT_COUNT_NO_CACHE;
         }
-        if (cachedCount instanceof Long) {
-            return (Long) cachedCount;
-        }
+
         return ((Integer) cachedCount).longValue();
     }
 
@@ -39,10 +38,10 @@ public class RecruitmentCacheService {
     public void plusOneToRecruitmentCount(
         String cacheKey
     ) {
-        Long cachedCount = redisTemplate.opsForValue().get(cacheKey);
+        Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
 
         if (Objects.nonNull(cachedCount)) {
-            registerRecruitmentCount(cacheKey, cachedCount + COUNT_ONE);
+            registerRecruitmentCount(cacheKey, (Integer) cachedCount + COUNT_ONE);
         }
 
         long dbRecruitmentCount = recruitmentRepository.count();
@@ -53,10 +52,10 @@ public class RecruitmentCacheService {
     public void minusOneToRecruitmentCount(
         String cacheKey
     ) {
-        Long cachedCount = redisTemplate.opsForValue().get(cacheKey);
+        Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
 
         if (Objects.nonNull(cachedCount)) {
-            registerRecruitmentCount(cacheKey, cachedCount - COUNT_ONE);
+            registerRecruitmentCount(cacheKey, (Integer) cachedCount - COUNT_ONE);
         }
 
         long dbRecruitmentCount = recruitmentRepository.count();

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -16,10 +16,10 @@ public class RecruitmentCacheService {
     private static final Long RECRUITMENT_COUNT_NO_CACHE = -1L;
     private static final Long COUNT_ONE = 1L;
 
-    public Long getRecruitmentCount(
-        String cacheKey
-    ) {
-        Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
+    private static final String RECRUITMENT_CACHE_KEY = "recruitment:count";
+
+    public Long getRecruitmentCount() {
+        Object cachedCount = redisTemplate.opsForValue().get(RECRUITMENT_CACHE_KEY);
 
         if (Objects.isNull(cachedCount)) {
             return RECRUITMENT_COUNT_NO_CACHE;
@@ -33,37 +33,32 @@ public class RecruitmentCacheService {
     }
 
     public void registerRecruitmentCount(
-        String cacheKey,
         Long count
     ) {
-        redisTemplate.opsForValue().set(cacheKey, count);
+        redisTemplate.opsForValue().set(RECRUITMENT_CACHE_KEY, count);
     }
 
-    public void plusOneToRecruitmentCount(
-        String cacheKey
-    ) {
-        Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
+    public void plusOneToRecruitmentCount() {
+        Object cachedCount = redisTemplate.opsForValue().get(RECRUITMENT_CACHE_KEY);
 
         if (Objects.nonNull(cachedCount)) {
-            registerRecruitmentCount(cacheKey, (Integer) cachedCount + COUNT_ONE);
+            registerRecruitmentCount((Integer) cachedCount + COUNT_ONE);
         }
 
         long dbRecruitmentCount = recruitmentRepository.count();
 
-        registerRecruitmentCount(cacheKey, dbRecruitmentCount);
+        registerRecruitmentCount(dbRecruitmentCount);
     }
 
-    public void minusOneToRecruitmentCount(
-        String cacheKey
-    ) {
-        Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
+    public void minusOneToRecruitmentCount() {
+        Object cachedCount = redisTemplate.opsForValue().get(RECRUITMENT_CACHE_KEY);
 
         if (Objects.nonNull(cachedCount)) {
-            registerRecruitmentCount(cacheKey, (Integer) cachedCount - COUNT_ONE);
+            registerRecruitmentCount((Integer) cachedCount - COUNT_ONE);
         }
 
         long dbRecruitmentCount = recruitmentRepository.count();
 
-        registerRecruitmentCount(cacheKey, dbRecruitmentCount);
+        registerRecruitmentCount(dbRecruitmentCount);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -1,0 +1,38 @@
+package com.clova.anifriends.domain.recruitment.service;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final Long RECRUITMENT_COUNT_NO_CACHE = -1L;
+
+    public Long getRecruitmentCount(
+        String cacheKey
+    ) {
+        Object cachedCount = redisTemplate.opsForValue().get(cacheKey);
+
+        if (Objects.isNull(cachedCount)) {
+            return RECRUITMENT_COUNT_NO_CACHE;
+        }
+
+        if (cachedCount instanceof Long) {
+            return (Long) cachedCount;
+        }
+
+        return ((Integer) cachedCount).longValue();
+    }
+
+    public void registerRecruitmentCount(
+        String cacheKey,
+        Long dbCount
+    ) {
+        redisTemplate.opsForValue().set(cacheKey, dbCount);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -36,7 +36,6 @@ public class RecruitmentService {
     private final RecruitmentCacheService recruitmentCacheService;
 
     private static final Long RECRUITMENT_COUNT_NO_CACHE = -1L;
-    private static final String RECRUITMENT_CACHE_KEY = "recruitment:count";
 
     @Transactional
     public RegisterRecruitmentResponse registerRecruitment(
@@ -60,7 +59,7 @@ public class RecruitmentService {
             imageUrls);
 
         recruitmentRepository.save(recruitment);
-        recruitmentCacheService.plusOneToRecruitmentCount(RECRUITMENT_CACHE_KEY);
+        recruitmentCacheService.plusOneToRecruitmentCount();
 
         return RegisterRecruitmentResponse.from(recruitment);
     }
@@ -164,7 +163,7 @@ public class RecruitmentService {
             pageable);
 
         Long cachedRecruitmentCount = recruitmentCacheService.getRecruitmentCount(
-            RECRUITMENT_CACHE_KEY);
+        );
 
         if (Objects.isNull(keyword) &&
             Objects.isNull(startDate) &&
@@ -190,7 +189,7 @@ public class RecruitmentService {
             shelterNameContains
         );
 
-        recruitmentCacheService.registerRecruitmentCount(RECRUITMENT_CACHE_KEY, dbRecruitmentCount);
+        recruitmentCacheService.registerRecruitmentCount(dbRecruitmentCount);
 
         return FindRecruitmentsResponse.fromV2(recruitments, dbRecruitmentCount);
     }
@@ -238,7 +237,7 @@ public class RecruitmentService {
         applicationEventPublisher.publishEvent(new ImageDeletionEvent(imagesToDelete));
 
         recruitmentRepository.delete(recruitment);
-        recruitmentCacheService.minusOneToRecruitmentCount(RECRUITMENT_CACHE_KEY);
+        recruitmentCacheService.minusOneToRecruitmentCount();
     }
 
     private Recruitment getRecruitmentByShelterWithImages(Long shelterId, Long recruitmentId) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.recruitment.service;
 
 import com.clova.anifriends.domain.common.event.ImageDeletionEvent;
 import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.controller.RecruitmentStatusFilter;
 import com.clova.anifriends.domain.recruitment.dto.response.FindCompletedRecruitmentsResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentDetailResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterIdResponse;
@@ -35,7 +36,7 @@ public class RecruitmentService {
     private final RecruitmentCacheService recruitmentCacheService;
 
     private static final Long RECRUITMENT_COUNT_NO_CACHE = -1L;
-    private static final String RECRUITMENT_CACHE_KEY = "recruitment:count:";
+    private static final String RECRUITMENT_CACHE_KEY = "recruitment:count";
 
     @Transactional
     public RegisterRecruitmentResponse registerRecruitment(
@@ -165,9 +166,13 @@ public class RecruitmentService {
         Long cachedRecruitmentCount = recruitmentCacheService.getRecruitmentCount(
             RECRUITMENT_CACHE_KEY);
 
-        if (Objects.isNull(keyword) && Objects.isNull(startDate) && Objects.isNull(endDate)
-            && Objects.isNull(isClosed) && Objects.equals(titleContains, true) && Objects.equals(
-            contentContains, true) && Objects.equals(shelterNameContains, true)
+        if (Objects.isNull(keyword) &&
+            Objects.isNull(startDate) &&
+            Objects.isNull(endDate) &&
+            Objects.equals(isClosed, RecruitmentStatusFilter.ALL.getIsClosed()) &&
+            Objects.equals(titleContains, true) &&
+            Objects.equals(contentContains, true) &&
+            Objects.equals(shelterNameContains, true)
         ) {
             if (!Objects.equals(cachedRecruitmentCount, RECRUITMENT_COUNT_NO_CACHE)) {
                 return FindRecruitmentsResponse.fromV2(recruitments,

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -233,6 +233,7 @@ public class RecruitmentService {
         applicationEventPublisher.publishEvent(new ImageDeletionEvent(imagesToDelete));
 
         recruitmentRepository.delete(recruitment);
+        recruitmentCacheService.minusOneToRecruitmentCount(RECRUITMENT_CACHE_KEY);
     }
 
     private Recruitment getRecruitmentByShelterWithImages(Long shelterId, Long recruitmentId) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -57,7 +57,10 @@ public class RecruitmentService {
             endTime,
             deadline,
             imageUrls);
+
         recruitmentRepository.save(recruitment);
+        recruitmentCacheService.plusOneToRecruitmentCount(RECRUITMENT_CACHE_KEY);
+
         return RegisterRecruitmentResponse.from(recruitment);
     }
 
@@ -163,8 +166,8 @@ public class RecruitmentService {
             RECRUITMENT_CACHE_KEY);
 
         if (Objects.isNull(keyword) && Objects.isNull(startDate) && Objects.isNull(endDate)
-            && Objects.isNull(isClosed) && Objects.isNull(titleContains) && Objects.isNull(
-            contentContains) && Objects.isNull(shelterNameContains)
+            && Objects.isNull(isClosed) && Objects.equals(titleContains, true) && Objects.equals(
+            contentContains, true) && Objects.equals(shelterNameContains, true)
         ) {
             if (!Objects.equals(cachedRecruitmentCount, RECRUITMENT_COUNT_NO_CACHE)) {
                 return FindRecruitmentsResponse.fromV2(recruitments,

--- a/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableCaching
@@ -26,11 +26,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Integer> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return template;
     }
 }

--- a/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
@@ -33,4 +33,14 @@ public class RedisConfig {
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return template;
     }
+
+    @Bean
+    public RedisTemplate<String, Long> countRedisTemplate(
+        RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
 }

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.clova.anifriends.base;
 
+import com.clova.anifriends.base.config.RedisTestContainerConfig;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
 import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
@@ -7,6 +8,7 @@ import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.review.repository.ReviewRepository;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
+import com.clova.anifriends.global.config.RedisConfig;
 import com.clova.anifriends.global.config.SecurityConfig;
 import jakarta.persistence.EntityManager;
 import java.util.Properties;
@@ -19,14 +21,16 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("dev")
-@Import({SecurityConfig.class})
-public abstract class BaseIntegrationTest {
+@Import({SecurityConfig.class, RedisConfig.class})
+public abstract class BaseIntegrationTest extends RedisTestContainerConfig {
 
     @BeforeAll
     static void beforeAll() {
         Properties properties = System.getProperties();
-        properties.setProperty("ACCESS_TOKEN_SECRET", "_4RNpxi%CB:eoO6a>j=#|*e#$Fp%%aX{dFi%.!Y(ZIy'UMuAt.9.;LxpWn2BZV*");
-        properties.setProperty("REFRESH_TOKEN_SECRET", "Tlolt.z[e$1yO!%Uc\"F*QH=uf0vp3U5s5{X5=g=*nDZ>BWMIKIf9nzd6et2.:Fb");
+        properties.setProperty("ACCESS_TOKEN_SECRET",
+            "_4RNpxi%CB:eoO6a>j=#|*e#$Fp%%aX{dFi%.!Y(ZIy'UMuAt.9.;LxpWn2BZV*");
+        properties.setProperty("REFRESH_TOKEN_SECRET",
+            "Tlolt.z[e$1yO!%Uc\"F*QH=uf0vp3U5s5{X5=g=*nDZ>BWMIKIf9nzd6et2.:Fb");
     }
 
     @Autowired

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -1,7 +1,5 @@
-package com.clova.anifriends.base.config;
+package com.clova.anifriends.base;
 
-import com.clova.anifriends.base.DatabaseCleaner;
-import com.clova.anifriends.base.TestContainerStarter;
 import com.clova.anifriends.domain.animal.repository.AnimalRepository;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalCacheServiceTest.java
@@ -2,7 +2,7 @@ package com.clova.anifriends.domain.animal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsResponse.FindAnimalResponse;
 import com.clova.anifriends.domain.animal.repository.AnimalCacheRepository;

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.AnimalImage;
 import com.clova.anifriends.domain.animal.dto.request.RegisterAnimalRequest;

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantIntegrationTest.java
@@ -3,7 +3,7 @@ package com.clova.anifriends.domain.applicant.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;

--- a/src/test/java/com/clova/anifriends/domain/chat/service/ChatRoomIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/chat/service/ChatRoomIntegrationTest.java
@@ -3,7 +3,7 @@ package com.clova.anifriends.domain.chat.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.auth.jwt.UserRole;
 import com.clova.anifriends.domain.chat.ChatMessage;
 import com.clova.anifriends.domain.chat.ChatRoom;

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -34,7 +34,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        RECRUITMENT_CACHE_KEY = "recruitment:count:";
+        RECRUITMENT_CACHE_KEY = "recruitment:count";
         shelter = ShelterFixture.shelter();
         shelterRepository.save(shelter);
     }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -97,8 +97,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             recruitmentRepository.save(recruitment);
 
             // when
-            Long recruitmentCount = recruitmentCacheService.getRecruitmentCount(
-                RECRUITMENT_CACHE_KEY);
+            Long recruitmentCount = recruitmentCacheService.getRecruitmentCount();
 
             // then
             assertThat(recruitmentCount).isEqualTo(-1L);
@@ -129,7 +128,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
             // then
             assertThat(recruitmentRepository.count()).isEqualTo(
-                recruitmentCacheService.getRecruitmentCount(RECRUITMENT_CACHE_KEY));
+                recruitmentCacheService.getRecruitmentCount());
         }
     }
 
@@ -152,7 +151,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
             // then
             assertThat(recruitmentRepository.count()).isEqualTo(
-                recruitmentCacheService.getRecruitmentCount(RECRUITMENT_CACHE_KEY));
+                recruitmentCacheService.getRecruitmentCount());
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -1,0 +1,83 @@
+package com.clova.anifriends.domain.recruitment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.clova.anifriends.base.BaseIntegrationTest;
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.controller.RecruitmentStatusFilter;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse;
+import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Transactional
+@Testcontainers
+class RecruitmentCacheServiceTest extends BaseIntegrationTest {
+
+    @Autowired
+    RecruitmentCacheService recruitmentCacheService;
+
+    @Autowired
+    RecruitmentService recruitmentService;
+
+    Shelter shelter;
+
+
+    @Nested
+    @DisplayName("findRecruitmentsV2 실행 시 recruitmentCount를 가져올 때 ")
+    class findRecruitments {
+
+        @BeforeEach
+        void setUp() {
+            shelter = ShelterFixture.shelter();
+            shelterRepository.save(shelter);
+        }
+
+        @Test
+        @DisplayName("성공: db에 없으면 redis에서 가져온다.")
+        void getCachedRecruitmentCount() {
+            // given
+            Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+            Recruitment savedRecruitment = recruitmentRepository.save(recruitment);
+
+            String keyword = null;
+            LocalDate startDate = null;
+            LocalDate endDate = null;
+            String isClosed = RecruitmentStatusFilter.ALL.getName();
+            boolean title = true;
+            boolean content = true;
+            boolean shelterName = true;
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            // when
+            FindRecruitmentsResponse dbRecruitmentCountResponse = recruitmentService.findRecruitmentsV2(
+                keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
+                shelterName, savedRecruitment.getCreatedAt(),
+                savedRecruitment.getRecruitmentId(), pageRequest
+            );
+
+            FindRecruitmentsResponse cachedRecruitmentCountResponse = recruitmentService.findRecruitmentsV2(
+                keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
+                shelterName, savedRecruitment.getCreatedAt(),
+                savedRecruitment.getRecruitmentId(), pageRequest
+            );
+
+            // then
+            assertThat(dbRecruitmentCountResponse.pageInfo().totalElements()).isEqualTo(
+                cachedRecruitmentCountResponse.pageInfo().totalElements());
+        }
+
+    }
+
+}

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -39,7 +39,6 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
         shelterRepository.save(shelter);
     }
 
-
     @Nested
     @DisplayName("findRecruitmentsV2 실행 시 recruitmentCount를 가져올 때 ")
     class GetRecruitmentCountTest {

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -42,7 +42,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
     @Nested
     @DisplayName("findRecruitmentsV2 실행 시 recruitmentCount를 가져올 때 ")
-    class GetRecruitmentCount {
+    class GetRecruitmentCountTest {
 
         @Test
         @DisplayName("성공: redis에 없으면 db에서 가져오고 redis에 있으면 캐시에서 가져온다.")
@@ -83,10 +83,10 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
     @Nested
     @DisplayName("registerRecruitment 실행 시 ")
-    class PlusOneToRecruitmentCount {
+    class PlusOneToRecruitmentCountTest {
 
         @Test
-        @DisplayName("성공: redis에 값이 없으면 값을 갱신하고 redis에 값이 있으면 count를 +1 증가시킨다.")
+        @DisplayName("성공: redis에 값이 없으면 값을 갱신하고 redis에 값이 있으면 count를 하나 증가시킨다.")
         void plusOneToRecruitmentCount() {
             // given
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
@@ -109,4 +109,26 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("deleteRecruitment 실행 시 ")
+    class MinusOneToRecruitmentCountTest {
+
+        @Test
+        @DisplayName("성공: redis에 값이 없으면 값을 갱신하고 redis에 값이 있으면 count를 하나 감소시킨다.")
+        void MinusOneToRecruitmentCount() {
+            // given
+            Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+            Recruitment savedRecruitment = recruitmentRepository.save(recruitment);
+
+            // when
+            recruitmentService.deleteRecruitment(
+                shelter.getShelterId(),
+                savedRecruitment.getRecruitmentId()
+            );
+
+            // then
+            assertThat(recruitmentRepository.count()).isEqualTo(
+                recruitmentCacheService.getRecruitmentCount(RECRUITMENT_CACHE_KEY));
+        }
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.RecruitmentImage;

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -249,6 +249,55 @@ class RecruitmentServiceTest {
             assertThat(findRecruitment.shelterImageUrl())
                 .isEqualTo(recruitment.getShelter().getImage());
         }
+
+        @Test
+        @DisplayName("성공: Request Param이 다 null인 경우")
+        void findRecruitmentsV2WhenArgsAreNull() {
+            //given
+            String keyword = null;
+            LocalDate startDate = null;
+            LocalDate endDate = null;
+            String isClosed = RecruitmentStatusFilter.ALL.getName();
+            boolean title = true;
+            boolean content = true;
+            boolean shelterName = true;
+            LocalDateTime createdAt = LocalDateTime.now();
+            Long recruitmentId = 1L;
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Shelter shelter = shelter();
+            Recruitment recruitment = recruitment(shelter);
+            ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+            SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+            given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
+                recruitments);
+            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+                Long.valueOf(recruitments.getSize()));
+
+            //when
+            FindRecruitmentsResponse recruitmentsByVolunteer
+                = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
+                shelterName, createdAt, recruitmentId, pageRequest);
+
+            //then
+            PageInfo pageInfo = recruitmentsByVolunteer.pageInfo();
+            assertThat(pageInfo.totalElements()).isEqualTo(recruitments.getSize());
+            FindRecruitmentResponse findRecruitment = recruitmentsByVolunteer.recruitments()
+                .get(0);
+            assertThat(findRecruitment.recruitmentTitle()).isEqualTo(recruitment.getTitle());
+            assertThat(findRecruitment.recruitmentStartTime()).isEqualTo(
+                recruitment.getStartTime());
+            assertThat(findRecruitment.recruitmentEndTime()).isEqualTo(recruitment.getEndTime());
+            assertThat(findRecruitment.recruitmentApplicantCount()).isEqualTo(
+                recruitment.getApplicantCount());
+            assertThat(findRecruitment.recruitmentCapacity()).isEqualTo(recruitment.getCapacity());
+            assertThat(findRecruitment.shelterName()).isEqualTo(recruitment.getShelter().getName());
+            assertThat(findRecruitment.shelterImageUrl())
+                .isEqualTo(recruitment.getShelter().getImage());
+        }
     }
 
     @Nested

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -61,6 +61,9 @@ class RecruitmentServiceTest {
     RecruitmentService recruitmentService;
 
     @Mock
+    RecruitmentCacheService recruitmentCacheService;
+
+    @Mock
     ShelterRepository shelterRepository;
 
     @Mock
@@ -197,8 +200,8 @@ class RecruitmentServiceTest {
 
         @Test
         @DisplayName("성공")
-        void findRecruitments() {
-            //give
+        void findRecruitmentsV2() {
+            //given
             String keyword = "keyword";
             LocalDate startDate = LocalDate.now();
             LocalDate endDate = LocalDate.now();
@@ -218,6 +221,8 @@ class RecruitmentServiceTest {
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
                 recruitments);
+            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+                Long.valueOf(recruitments.getSize()));
             given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName)).willReturn(Long.valueOf(recruitments.getSize()));
@@ -313,7 +318,8 @@ class RecruitmentServiceTest {
             Recruitment recruitment = recruitment(shelter);
             FindRecruitmentDetailResponse expected = findRecruitmentDetailResponse(recruitment);
 
-            when(recruitmentRepository.findRecruitmentDetail(anyLong())).thenReturn(Optional.of(recruitment));
+            when(recruitmentRepository.findRecruitmentDetail(anyLong())).thenReturn(
+                Optional.of(recruitment));
 
             // when
             FindRecruitmentDetailResponse result = recruitmentService.findRecruitmentDetail(
@@ -327,7 +333,8 @@ class RecruitmentServiceTest {
         @DisplayName("예외(RecruitmentNotFoundException): 존재하지 않는 모집글")
         void throwExceptionWhenRecruitmentIsNotExist() {
             // given
-            when(recruitmentRepository.findRecruitmentDetail(anyLong())).thenReturn(Optional.empty());
+            when(recruitmentRepository.findRecruitmentDetail(anyLong())).thenReturn(
+                Optional.empty());
 
             // when
             Exception exception = catchException(

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -221,7 +221,7 @@ class RecruitmentServiceTest {
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
                 recruitments);
-            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+            given(recruitmentCacheService.getRecruitmentCount()).willReturn(
                 Long.valueOf(recruitments.getSize()));
             given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
@@ -273,7 +273,7 @@ class RecruitmentServiceTest {
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
                 recruitments);
-            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+            given(recruitmentCacheService.getRecruitmentCount()).willReturn(
                 Long.valueOf(recruitments.getSize()));
 
             //when
@@ -322,7 +322,7 @@ class RecruitmentServiceTest {
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
                 recruitments);
-            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+            given(recruitmentCacheService.getRecruitmentCount()).willReturn(
                 Long.valueOf(recruitments.getSize()));
             given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
@@ -374,7 +374,7 @@ class RecruitmentServiceTest {
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
                 recruitments);
-            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+            given(recruitmentCacheService.getRecruitmentCount()).willReturn(
                 Long.valueOf(recruitments.getSize()));
             given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
@@ -426,7 +426,7 @@ class RecruitmentServiceTest {
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
                 title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
                 recruitments);
-            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+            given(recruitmentCacheService.getRecruitmentCount()).willReturn(
                 Long.valueOf(recruitments.getSize()));
             given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
                 RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -199,7 +199,7 @@ class RecruitmentServiceTest {
     class FindRecruitmentsV2Test {
 
         @Test
-        @DisplayName("성공")
+        @DisplayName("성공: 모든 필터가 존재")
         void findRecruitmentsV2() {
             //given
             String keyword = "keyword";
@@ -251,7 +251,7 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("성공: Request Param이 다 null인 경우")
+        @DisplayName("성공: Request Param이 모두 null")
         void findRecruitmentsV2WhenArgsAreNull() {
             //given
             String keyword = null;
@@ -275,6 +275,162 @@ class RecruitmentServiceTest {
                 recruitments);
             given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
                 Long.valueOf(recruitments.getSize()));
+
+            //when
+            FindRecruitmentsResponse recruitmentsByVolunteer
+                = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
+                shelterName, createdAt, recruitmentId, pageRequest);
+
+            //then
+            PageInfo pageInfo = recruitmentsByVolunteer.pageInfo();
+            assertThat(pageInfo.totalElements()).isEqualTo(recruitments.getSize());
+            FindRecruitmentResponse findRecruitment = recruitmentsByVolunteer.recruitments()
+                .get(0);
+            assertThat(findRecruitment.recruitmentTitle()).isEqualTo(recruitment.getTitle());
+            assertThat(findRecruitment.recruitmentStartTime()).isEqualTo(
+                recruitment.getStartTime());
+            assertThat(findRecruitment.recruitmentEndTime()).isEqualTo(recruitment.getEndTime());
+            assertThat(findRecruitment.recruitmentApplicantCount()).isEqualTo(
+                recruitment.getApplicantCount());
+            assertThat(findRecruitment.recruitmentCapacity()).isEqualTo(recruitment.getCapacity());
+            assertThat(findRecruitment.shelterName()).isEqualTo(recruitment.getShelter().getName());
+            assertThat(findRecruitment.shelterImageUrl())
+                .isEqualTo(recruitment.getShelter().getImage());
+        }
+
+        @Test
+        @DisplayName("성공: startDate, endDate만 null이 아닌 경우")
+        void findRecruitmentsV2WhenArgsAreNull3() {
+            //given
+            String keyword = null;
+            LocalDate startDate = LocalDate.now();
+            LocalDate endDate = LocalDate.now();
+            String isClosed = RecruitmentStatusFilter.ALL.getName();
+            boolean title = true;
+            boolean content = true;
+            boolean shelterName = true;
+            LocalDateTime createdAt = LocalDateTime.now();
+            Long recruitmentId = 1L;
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Shelter shelter = shelter();
+            Recruitment recruitment = recruitment(shelter);
+            ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+            SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+            given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
+                recruitments);
+            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+                Long.valueOf(recruitments.getSize()));
+            given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName)).willReturn(Long.valueOf(recruitments.getSize()));
+
+            //when
+            FindRecruitmentsResponse recruitmentsByVolunteer
+                = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
+                shelterName, createdAt, recruitmentId, pageRequest);
+
+            //then
+            PageInfo pageInfo = recruitmentsByVolunteer.pageInfo();
+            assertThat(pageInfo.totalElements()).isEqualTo(recruitments.getSize());
+            FindRecruitmentResponse findRecruitment = recruitmentsByVolunteer.recruitments()
+                .get(0);
+            assertThat(findRecruitment.recruitmentTitle()).isEqualTo(recruitment.getTitle());
+            assertThat(findRecruitment.recruitmentStartTime()).isEqualTo(
+                recruitment.getStartTime());
+            assertThat(findRecruitment.recruitmentEndTime()).isEqualTo(recruitment.getEndTime());
+            assertThat(findRecruitment.recruitmentApplicantCount()).isEqualTo(
+                recruitment.getApplicantCount());
+            assertThat(findRecruitment.recruitmentCapacity()).isEqualTo(recruitment.getCapacity());
+            assertThat(findRecruitment.shelterName()).isEqualTo(recruitment.getShelter().getName());
+            assertThat(findRecruitment.shelterImageUrl())
+                .isEqualTo(recruitment.getShelter().getImage());
+        }
+
+        @Test
+        @DisplayName("성공: title만 true고 나머지는 null인 경우")
+        void findRecruitmentsV2WhenArgsAreNull4() {
+            //given
+            String keyword = null;
+            LocalDate startDate = null;
+            LocalDate endDate = null;
+            String isClosed = RecruitmentStatusFilter.ALL.getName();
+            boolean title = true;
+            boolean content = false;
+            boolean shelterName = false;
+            LocalDateTime createdAt = LocalDateTime.now();
+            Long recruitmentId = 1L;
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Shelter shelter = shelter();
+            Recruitment recruitment = recruitment(shelter);
+            ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+            SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+            given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
+                recruitments);
+            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+                Long.valueOf(recruitments.getSize()));
+            given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName)).willReturn(Long.valueOf(recruitments.getSize()));
+
+            //when
+            FindRecruitmentsResponse recruitmentsByVolunteer
+                = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
+                shelterName, createdAt, recruitmentId, pageRequest);
+
+            //then
+            PageInfo pageInfo = recruitmentsByVolunteer.pageInfo();
+            assertThat(pageInfo.totalElements()).isEqualTo(recruitments.getSize());
+            FindRecruitmentResponse findRecruitment = recruitmentsByVolunteer.recruitments()
+                .get(0);
+            assertThat(findRecruitment.recruitmentTitle()).isEqualTo(recruitment.getTitle());
+            assertThat(findRecruitment.recruitmentStartTime()).isEqualTo(
+                recruitment.getStartTime());
+            assertThat(findRecruitment.recruitmentEndTime()).isEqualTo(recruitment.getEndTime());
+            assertThat(findRecruitment.recruitmentApplicantCount()).isEqualTo(
+                recruitment.getApplicantCount());
+            assertThat(findRecruitment.recruitmentCapacity()).isEqualTo(recruitment.getCapacity());
+            assertThat(findRecruitment.shelterName()).isEqualTo(recruitment.getShelter().getName());
+            assertThat(findRecruitment.shelterImageUrl())
+                .isEqualTo(recruitment.getShelter().getImage());
+        }
+
+        @Test
+        @DisplayName("성공: content만 true고 나머지는 null인 경우")
+        void findRecruitmentsV2WhenArgsAreNull5() {
+            //given
+            String keyword = null;
+            LocalDate startDate = null;
+            LocalDate endDate = null;
+            String isClosed = RecruitmentStatusFilter.ALL.getName();
+            boolean title = false;
+            boolean content = true;
+            boolean shelterName = false;
+            LocalDateTime createdAt = LocalDateTime.now();
+            Long recruitmentId = 1L;
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Shelter shelter = shelter();
+            Recruitment recruitment = recruitment(shelter);
+            ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+            SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+            given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
+                recruitments);
+            given(recruitmentCacheService.getRecruitmentCount(any())).willReturn(
+                Long.valueOf(recruitments.getSize()));
+            given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
+                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
+                title, content, shelterName)).willReturn(Long.valueOf(recruitments.getSize()));
 
             //when
             FindRecruitmentsResponse recruitmentsByVolunteer

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterIntegrationTest.java
@@ -2,7 +2,7 @@ package com.clova.anifriends.domain.shelter.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.dto.response.RegisterShelterResponse;

--- a/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerIntegrationTest.java
@@ -2,7 +2,7 @@ package com.clova.anifriends.domain.volunteer.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.clova.anifriends.base.config.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.VolunteerImage;
 import com.clova.anifriends.domain.volunteer.dto.response.RegisterVolunteerResponse;


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자 입장에서 모집글 검색 시 `Request Param에 아무 조건도 없을 때` count가 캐시에 있으면 캐시에서 가져옵니다.
  - 캐시에 없으면 db에서 가져오고, 캐시에 count를 저장합니다.
- 봉사자 입장에서 모집글 등록 시 캐시에 recruitmentCount가 있다면 증가한다.
  - 캐시에 없으면 db에서 가져오고, 캐시에 갱신된 count를 저장합니다.
- 봉사자 입장에서 모집글 삭제 시 캐시에 recruitmentCount가 있다면 캐시에 있는 값을 감소한다.
  - 캐시에 없으면 db에서 가져오고, 캐시에 갱신된 count를 저장합니다.
 
### 📝 작업 요약
- 봉사자 입장에서 모집글 검색, 등록, 삭제 시 캐시에서 데이터를 가져옵니다.

### 💡 관련 이슈
- close #314 
