### PR TITLE
refactor: 봉사 모집글 목록을 캐싱하여 응답 속도를 개선한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
@@ -11,6 +11,12 @@ public record FindRecruitmentsResponse(
     List<FindRecruitmentResponse> recruitments,
     PageInfo pageInfo) {
 
+    public static FindRecruitmentsResponse fromCached(
+        Slice<FindRecruitmentResponse> cachedRecruitments, Long count) {
+        PageInfo pageInfo = PageInfo.of(count, cachedRecruitments.hasNext());
+        return new FindRecruitmentsResponse(cachedRecruitments.getContent(), pageInfo);
+    }
+
     public record FindRecruitmentResponse(
         Long recruitmentId,
         String recruitmentTitle,

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepository.java
@@ -68,7 +68,7 @@ public class RecruitmentCacheRepository {
         List<FindRecruitmentResponse> content = recruitments.stream()
             .limit(size)
             .toList();
-        boolean hasNext = recruitments.size() > PAGE_SIZE;
+        boolean hasNext = recruitments.size() > size;
         return new SliceImpl<>(content, pageable, hasNext);
     }
 

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepository.java
@@ -1,4 +1,4 @@
-package com.clova.anifriends.domain.recruitment.service;
+package com.clova.anifriends.domain.recruitment.repository;
 
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
@@ -10,11 +10,11 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Repository;
 
-@Service
+@Repository
 @RequiredArgsConstructor
-public class RecruitmentCacheService {
+public class RecruitmentCacheRepository {
 
     private static final String RECRUITMENT_KEY = "recruitment";
     private static final int UNTIL_LAST_ELEMENT = -1;
@@ -23,7 +23,7 @@ public class RecruitmentCacheService {
 
     private final RedisTemplate<String, FindRecruitmentResponse> redisTemplate;
 
-    public void pushNewRecruitment(final Recruitment recruitment) {
+    public void save(final Recruitment recruitment) {
         FindRecruitmentResponse recruitmentResponse = FindRecruitmentResponse.from(recruitment);
         ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments = redisTemplate.opsForZSet();
         long createdAtScore = getCreatedAtScore(recruitment);
@@ -43,7 +43,7 @@ public class RecruitmentCacheService {
         }
     }
 
-    public List<FindRecruitmentResponse> getCachedRecruitments() {
+    public List<FindRecruitmentResponse> findAll() {
         ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments
             = redisTemplate.opsForZSet();
         Set<FindRecruitmentResponse> recruitments
@@ -55,7 +55,7 @@ public class RecruitmentCacheService {
             .toList();
     }
 
-    public void updateCachedRecruitment(final Recruitment recruitment) {
+    public void update(final Recruitment recruitment) {
         long createdAtScore = getCreatedAtScore(recruitment);
         ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments
             = redisTemplate.opsForZSet();
@@ -84,7 +84,7 @@ public class RecruitmentCacheService {
         return findRecruitmentResponse.recruitmentId().equals(recruitment.getRecruitmentId());
     }
 
-    public void deleteCachedRecruitment(final Recruitment recruitment) {
+    public void delete(final Recruitment recruitment) {
         ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments
             = redisTemplate.opsForZSet();
         FindRecruitmentResponse recruitmentResponse = FindRecruitmentResponse.from(recruitment);

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -3,7 +3,6 @@ package com.clova.anifriends.domain.recruitment.service;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -42,13 +41,15 @@ public class RecruitmentCacheService {
         }
     }
 
-    public List<FindRecruitmentResponse> findRecruitments() {
-        ZSetOperations<String, FindRecruitmentResponse> stringObjectZSetOperations = redisTemplate.opsForZSet();
-        Set<FindRecruitmentResponse> set = stringObjectZSetOperations.reverseRange(RECRUITMENT_KEY, ZERO,
-            CACHED_SIZE);
-        if(Objects.nonNull(set)) {
-            return new ArrayList<>(set);
+    public List<FindRecruitmentResponse> getCachedRecruitments() {
+        ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments
+            = redisTemplate.opsForZSet();
+        Set<FindRecruitmentResponse> recruitments
+            = cachedRecruitments.reverseRange(RECRUITMENT_KEY, ZERO, CACHED_SIZE);
+        if(Objects.isNull(recruitments)) {
+            return List.of();
         }
-        return List.of();
+        return recruitments.stream()
+            .toList();
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -1,0 +1,31 @@
+package com.clova.anifriends.domain.recruitment.service;
+
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.repository.RecruitmentCacheRepository;
+import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentCacheService {
+
+    private static final int MAX_CACHED_SIZE = 30;
+
+    private final RecruitmentRepository recruitmentRepository;
+    private final RecruitmentCacheRepository recruitmentCacheRepository;
+
+    @Transactional(readOnly = true)
+    public void synchronizeCache() {
+        PageRequest pageRequest = PageRequest.of(0, MAX_CACHED_SIZE);
+        Slice<Recruitment> recruitmentSlice = recruitmentRepository.findRecruitmentsV2(null, null,
+            null, null, true, true, true, null,
+            null, pageRequest);
+        List<Recruitment> findRecruitments = recruitmentSlice.getContent();
+        findRecruitments.forEach(recruitmentCacheRepository::save);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheService.java
@@ -1,0 +1,45 @@
+package com.clova.anifriends.domain.recruitment.service;
+
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentCacheService {
+
+    public static final String RECRUITMENT_KEY = "recruitment";
+    private final RedisTemplate<String, FindRecruitmentResponse> redisTemplate;
+
+    public void registerRecruitment(final Recruitment recruitment) {
+        FindRecruitmentResponse recruitmentResponse = FindRecruitmentResponse.from(recruitment);
+        ZSetOperations<String, FindRecruitmentResponse> stringObjectZSetOperations = redisTemplate.opsForZSet();
+        long epochSecond = recruitment.getCreatedAt().toEpochSecond(
+            ZoneOffset.of("+09:00"));
+        System.out.println(epochSecond);
+        stringObjectZSetOperations.add(RECRUITMENT_KEY, recruitmentResponse, epochSecond);
+        Set<FindRecruitmentResponse> set = stringObjectZSetOperations.range(RECRUITMENT_KEY,
+            1, -1);
+        if (Objects.nonNull(set) && set.size() > 20) {
+            stringObjectZSetOperations.popMin(RECRUITMENT_KEY);
+        }
+    }
+
+    public List<FindRecruitmentResponse> findRecruitments() {
+        ZSetOperations<String, FindRecruitmentResponse> stringObjectZSetOperations = redisTemplate.opsForZSet();
+        Set<FindRecruitmentResponse> set = stringObjectZSetOperations.reverseRange(RECRUITMENT_KEY, 1,
+            20);
+        if(Objects.nonNull(set)) {
+            return new ArrayList<>(set);
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -54,7 +54,6 @@ public class RecruitmentService {
             deadline,
             imageUrls);
         recruitmentRepository.save(recruitment);
-        recruitmentCacheService.registerRecruitment(recruitment);
         return RegisterRecruitmentResponse.from(recruitment);
     }
 

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -7,6 +7,7 @@ import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentDetai
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterIdResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsByShelterResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentCacheRepository;
@@ -17,6 +18,7 @@ import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -55,6 +57,7 @@ public class RecruitmentService {
             deadline,
             imageUrls);
         recruitmentRepository.save(recruitment);
+        recruitmentCacheRepository.save(recruitment);
         return RegisterRecruitmentResponse.from(recruitment);
     }
 
@@ -144,6 +147,24 @@ public class RecruitmentService {
         Long recruitmentId,
         Pageable pageable
     ) {
+        Long count = recruitmentRepository.countFindRecruitmentsV2(
+            keyword,
+            startDate,
+            endDate,
+            isClosed,
+            titleContains,
+            contentContains,
+            shelterNameContains
+        );
+
+        if (findRecruitmentsWithoutCondition(keyword, startDate, endDate, isClosed, titleContains,
+            contentContains, shelterNameContains, recruitmentId)) {
+            Slice<FindRecruitmentResponse> cachedRecruitments
+                = recruitmentCacheRepository.findAll(pageable);
+            if(canTrustCached(cachedRecruitments)) {
+                return FindRecruitmentsResponse.fromCached(cachedRecruitments, count);
+            }
+        }
         Slice<Recruitment> recruitments = recruitmentRepository.findRecruitmentsV2(
             keyword,
             startDate,
@@ -155,23 +176,25 @@ public class RecruitmentService {
             createdAt,
             recruitmentId,
             pageable);
-
-        Long count = recruitmentRepository.countFindRecruitmentsV2(
-            keyword,
-            startDate,
-            endDate,
-            isClosed,
-            titleContains,
-            contentContains,
-            shelterNameContains
-        );
-
         return FindRecruitmentsResponse.fromV2(recruitments, count);
+    }
+
+    private boolean canTrustCached(Slice<FindRecruitmentResponse> cachedRecruitments) {
+        return cachedRecruitments.hasNext();
+    }
+
+    private boolean findRecruitmentsWithoutCondition(String keyword, LocalDate startDate,
+        LocalDate endDate, Boolean isClosed, Boolean titleContains, Boolean contentContains,
+        Boolean shelterNameContains, Long recruitmentId) {
+        return Objects.isNull(keyword) && titleContains && contentContains && shelterNameContains
+            && Objects.isNull(startDate) && Objects.isNull(endDate) && Objects.isNull(isClosed)
+            && Objects.isNull(recruitmentId);
     }
 
     @Transactional
     public void closeRecruitment(Long shelterId, Long recruitmentId) {
         Recruitment recruitment = getRecruitmentByShelter(shelterId, recruitmentId);
+        recruitmentCacheRepository.update(recruitment);
         recruitment.closeRecruitment();
     }
 
@@ -201,6 +224,7 @@ public class RecruitmentService {
             content,
             imageUrls
         );
+        recruitmentCacheRepository.update(recruitment);
     }
 
     @Transactional
@@ -212,6 +236,7 @@ public class RecruitmentService {
         applicationEventPublisher.publishEvent(new ImageDeletionEvent(imagesToDelete));
 
         recruitmentRepository.delete(recruitment);
+        recruitmentCacheRepository.delete(recruitment);
     }
 
     private Recruitment getRecruitmentByShelterWithImages(Long shelterId, Long recruitmentId) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -31,6 +31,7 @@ public class RecruitmentService {
     private final ShelterRepository shelterRepository;
     private final RecruitmentRepository recruitmentRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final RecruitmentCacheService recruitmentCacheService;
 
     @Transactional
     public RegisterRecruitmentResponse registerRecruitment(
@@ -53,6 +54,7 @@ public class RecruitmentService {
             deadline,
             imageUrls);
         recruitmentRepository.save(recruitment);
+        recruitmentCacheService.registerRecruitment(recruitment);
         return RegisterRecruitmentResponse.from(recruitment);
     }
 

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -9,6 +9,7 @@ import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsBySh
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.RegisterRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
+import com.clova.anifriends.domain.recruitment.repository.RecruitmentCacheRepository;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
@@ -31,7 +32,7 @@ public class RecruitmentService {
     private final ShelterRepository shelterRepository;
     private final RecruitmentRepository recruitmentRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final RecruitmentCacheService recruitmentCacheService;
+    private final RecruitmentCacheRepository recruitmentCacheRepository;
 
     @Transactional
     public RegisterRecruitmentResponse registerRecruitment(

--- a/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.clova.anifriends.global.config;
 
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -7,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableCaching
@@ -26,11 +28,13 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Integer> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+    public RedisTemplate<String, FindRecruitmentResponse> recruitmentRedisTemplate(
+        RedisConnectionFactory connectionFactory,
+        ObjectMapper objectMapper) {
+        RedisTemplate<String, FindRecruitmentResponse> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, FindRecruitmentResponse.class));
         return template;
     }
 }

--- a/src/main/java/com/clova/anifriends/global/event/CacheWarmer.java
+++ b/src/main/java/com/clova/anifriends/global/event/CacheWarmer.java
@@ -1,0 +1,19 @@
+package com.clova.anifriends.global.event;
+
+import com.clova.anifriends.domain.recruitment.service.RecruitmentCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CacheWarmer {
+
+    private final RecruitmentCacheService recruitmentCacheService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    void synchronizeRecruitmentCache() {
+        recruitmentCacheService.synchronizeCache();
+    }
+}

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.clova.anifriends.base;
 
+import com.clova.anifriends.base.config.RedisTestContainerConfig;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
 import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
@@ -7,6 +8,7 @@ import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.review.repository.ReviewRepository;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
+import com.clova.anifriends.global.config.RedisConfig;
 import com.clova.anifriends.global.config.SecurityConfig;
 import jakarta.persistence.EntityManager;
 import java.util.Properties;
@@ -19,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("dev")
-@Import({SecurityConfig.class})
+@Import({SecurityConfig.class, RedisTestContainerConfig.class, RedisConfig.class})
 public abstract class BaseIntegrationTest {
 
     @BeforeAll

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.clova.anifriends.base;
 
-import com.clova.anifriends.base.config.RedisTestContainerConfig;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
 import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
@@ -11,8 +10,6 @@ import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
 import com.clova.anifriends.global.config.RedisConfig;
 import com.clova.anifriends.global.config.SecurityConfig;
 import jakarta.persistence.EntityManager;
-import java.util.Properties;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,15 +18,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("dev")
-@Import({SecurityConfig.class, RedisTestContainerConfig.class, RedisConfig.class})
-public abstract class BaseIntegrationTest {
-
-    @BeforeAll
-    static void beforeAll() {
-        Properties properties = System.getProperties();
-        properties.setProperty("ACCESS_TOKEN_SECRET", "_4RNpxi%CB:eoO6a>j=#|*e#$Fp%%aX{dFi%.!Y(ZIy'UMuAt.9.;LxpWn2BZV*");
-        properties.setProperty("REFRESH_TOKEN_SECRET", "Tlolt.z[e$1yO!%Uc\"F*QH=uf0vp3U5s5{X5=g=*nDZ>BWMIKIf9nzd6et2.:Fb");
-    }
+@Import({SecurityConfig.class, RedisConfig.class})
+public abstract class BaseIntegrationTest extends TestContainerStarter {
 
     @Autowired
     protected EntityManager entityManager;

--- a/src/test/java/com/clova/anifriends/base/TestContainerStarter.java
+++ b/src/test/java/com/clova/anifriends/base/TestContainerStarter.java
@@ -1,12 +1,10 @@
-package com.clova.anifriends.base.config;
+package com.clova.anifriends.base;
 
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
-public class RedisTestContainerConfig {
+public class TestContainerStarter {
 
     private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
     private static final int REDIS_PORT = 6379;

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.clova.anifriends.domain.recruitment.service;
+package com.clova.anifriends.domain.recruitment.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,14 +27,14 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class RecruitmentCacheServiceTest extends BaseIntegrationTest {
+class RecruitmentCacheRepositoryTest extends BaseIntegrationTest {
 
     private static final String RECRUITMENT_KEY = "recruitment";
     private static final int ZERO = 0;
     private static final int ALL_ELEMENT = -1;
 
     @Autowired
-    RecruitmentCacheService recruitmentCacheService;
+    RecruitmentCacheRepository recruitmentCacheRepository;
 
     @Autowired
     RedisTemplate<String, FindRecruitmentResponse> redisTemplate;
@@ -65,10 +65,10 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             recruitmentRepository.save(recruitment);
 
             //when
-            recruitmentCacheService.pushNewRecruitment(recruitment);
+            recruitmentCacheRepository.save(recruitment);
 
             //then
-            List<FindRecruitmentResponse> recruitments = recruitmentCacheService.getCachedRecruitments();
+            List<FindRecruitmentResponse> recruitments = recruitmentCacheRepository.findAll();
             assertThat(recruitments).hasSize(1);
             FindRecruitmentResponse recruitmentResponse = recruitments.get(0);
             assertThat(recruitmentResponse.recruitmentId())
@@ -91,7 +91,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
             //when
             for (Recruitment recruitment : recruitments) {
-                recruitmentCacheService.pushNewRecruitment(recruitment);
+                recruitmentCacheRepository.save(recruitment);
             }
 
             //then
@@ -103,7 +103,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
 
             System.out.println(recruitmentRepository.findAll().size());
             List<FindRecruitmentResponse> findRecruitments
-                = recruitmentCacheService.getCachedRecruitments();
+                = recruitmentCacheRepository.findAll();
             assertThat(findRecruitments).hasSize(20);
             assertThat(findRecruitments).map(FindRecruitmentResponse::recruitmentId)
                 .containsExactlyElementsOf(recruitmentIdsDesc);
@@ -130,7 +130,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             //given
             //when
             List<FindRecruitmentResponse> cachedRecruitments
-                = recruitmentCacheService.getCachedRecruitments();
+                = recruitmentCacheRepository.findAll();
 
             //then
             assertThat(cachedRecruitments)
@@ -153,12 +153,12 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             int hour = 0;
             for (Recruitment recruitment : recruitments) {
                 ReflectionTestUtils.setField(recruitment, "createdAt", now.plusHours(hour++));
-                recruitmentCacheService.pushNewRecruitment(recruitment);
+                recruitmentCacheRepository.save(recruitment);
             }
 
             //when
             List<FindRecruitmentResponse> cachedRecruitments
-                = recruitmentCacheService.getCachedRecruitments();
+                = recruitmentCacheRepository.findAll();
 
             //then
             List<Long> recruitmentIdsDesc = recruitments.stream()
@@ -197,7 +197,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             LocalDateTime now = LocalDateTime.now();
             for (Recruitment recruitment : recruitments) {
                 ReflectionTestUtils.setField(recruitment, "createdAt", now.plusHours(hour++));
-                recruitmentCacheService.pushNewRecruitment(recruitment);
+                recruitmentCacheRepository.save(recruitment);
             }
             Recruitment needToUpdateRecruitment = recruitments.get(20);
             FindRecruitmentResponse oldCachedRecruitment
@@ -205,11 +205,11 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             needToUpdateRecruitment.updateRecruitment("update", null, null, null, null, null, null);
 
             //when
-            recruitmentCacheService.updateCachedRecruitment(needToUpdateRecruitment);
+            recruitmentCacheRepository.update(needToUpdateRecruitment);
 
             //then
             List<FindRecruitmentResponse> cachedRecruitments
-                = recruitmentCacheService.getCachedRecruitments();
+                = recruitmentCacheRepository.findAll();
             FindRecruitmentResponse newCachedRecruitment
                 = FindRecruitmentResponse.from(needToUpdateRecruitment);
             assertThat(cachedRecruitments)
@@ -225,13 +225,13 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             LocalDateTime now = LocalDateTime.now();
             for (Recruitment recruitment : recruitments) {
                 ReflectionTestUtils.setField(recruitment, "createdAt", now.plusHours(hour++));
-                recruitmentCacheService.pushNewRecruitment(recruitment);
+                recruitmentCacheRepository.save(recruitment);
             }
             Recruitment needToUpdateRecruitment = recruitments.get(0);
             needToUpdateRecruitment.updateRecruitment("update", null, null, null, null, null, null);
 
             //when
-            recruitmentCacheService.updateCachedRecruitment(needToUpdateRecruitment);
+            recruitmentCacheRepository.update(needToUpdateRecruitment);
 
             //then
             long createdAtScore
@@ -262,10 +262,10 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             //given
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
             recruitmentRepository.save(recruitment);
-            recruitmentCacheService.pushNewRecruitment(recruitment);
+            recruitmentCacheRepository.save(recruitment);
 
             //when
-            recruitmentCacheService.deleteCachedRecruitment(recruitment);
+            recruitmentCacheRepository.delete(recruitment);
 
             //then
             ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments
@@ -284,7 +284,7 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
             recruitmentRepository.save(recruitment);
 
             //when
-            recruitmentCacheService.deleteCachedRecruitment(recruitment);
+            recruitmentCacheRepository.delete(recruitment);
 
             //then
             ZSetOperations<String, FindRecruitmentResponse> cachedRecruitments

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -1,0 +1,64 @@
+package com.clova.anifriends.domain.recruitment.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.repository.RecruitmentCacheRepository;
+import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
+import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class RecruitmentCacheServiceTest {
+
+    @InjectMocks
+    RecruitmentCacheService recruitmentCacheService;
+
+    @Mock
+    RecruitmentRepository recruitmentRepository;
+
+    @Mock
+    RecruitmentCacheRepository recruitmentCacheRepository;
+
+    @Nested
+    @DisplayName("synchronizeCache 메서드 실행 시")
+    class SynchronizeCacheTest {
+
+        @Test
+        @DisplayName("성공")
+        void synchronizeCache() {
+            //given
+            Shelter shelter = ShelterFixture.shelter();
+            List<Recruitment> recruitments = RecruitmentFixture.recruitments(shelter, 30);
+            PageRequest pageRequest = PageRequest.of(0, 30);
+            SliceImpl<Recruitment> recruitmentSlice = new SliceImpl<>(recruitments, pageRequest,
+                true);
+
+            given(recruitmentRepository.findRecruitmentsV2(null, null, null, null, true, true, true,
+                    null, null, pageRequest))
+                .willReturn(recruitmentSlice);
+
+            //when
+            recruitmentCacheService.synchronizeCache();
+
+            //then
+            then(recruitmentCacheRepository).should(times(30))
+                .save(any(Recruitment.class));
+
+        }
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -9,21 +9,41 @@ import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixtur
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 class RecruitmentCacheServiceTest extends BaseIntegrationTest {
+
+    private static final String RECRUITMENT_KEY = "recruitment";
+    private static final int ZERO = 0;
+    private static final int ALL_ELEMENT = -1;
 
     @Autowired
     RecruitmentCacheService recruitmentCacheService;
 
+    @Autowired
+    RedisTemplate<String, FindRecruitmentResponse> redisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.opsForZSet()
+            .removeRange(RECRUITMENT_KEY, ZERO, ALL_ELEMENT);
+    }
+
     @Nested
-    class RegisterRecruitmentTest {
+    @DisplayName("pushNewRecruitment 메서드 호출 시")
+    class PushNewRecruitment {
 
         Shelter shelter;
 
@@ -34,46 +54,54 @@ class RecruitmentCacheServiceTest extends BaseIntegrationTest {
         }
 
         @Test
+        @DisplayName("성공: 새로운 Recruitment 캐싱")
         void registerRecruitment() {
             //given
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+            recruitmentRepository.save(recruitment);
 
             //when
-            recruitmentCacheService.registerRecruitment(recruitment);
+            recruitmentCacheService.pushNewRecruitment(recruitment);
 
             //then
             List<FindRecruitmentResponse> recruitments = recruitmentCacheService.findRecruitments();
             assertThat(recruitments).hasSize(1);
+            FindRecruitmentResponse recruitmentResponse = recruitments.get(0);
+            assertThat(recruitmentResponse.recruitmentId())
+                .isEqualTo(recruitment.getRecruitmentId());
         }
 
         @Test
+        @DisplayName("성공: 새로운 Recruitment 100개 생성, 역순 20개 캐싱")
         void overflowTest() {
             //given
-            List<Recruitment> list = new ArrayList<>();
-            for (int i = 0; i < 30; i++) {
-                Recruitment recruitmented = RecruitmentFixture.recruitment(shelter);
-                recruitmentRepository.save(recruitmented);
-                list.add(recruitmented);
-            }
-            int i = 1;
-            for (Recruitment recruitment : list) {
-                ReflectionTestUtils.setField(recruitment, "createdAt", LocalDateTime.now().plusHours(i));
-                i++;
+            List<Recruitment> recruitments = IntStream.range(0, 100)
+                .mapToObj(i -> RecruitmentFixture.recruitment(shelter))
+                .toList();
+            recruitmentRepository.saveAll(recruitments);
+            LocalDateTime now = LocalDateTime.now();
+            int hour = 0;
+            for (Recruitment recruitment : recruitments) {
+                ReflectionTestUtils.setField(recruitment, "createdAt", now.plusHours(hour++));
             }
 
             //when
-            for (Recruitment recruitment : list) {
-                recruitmentCacheService.registerRecruitment(recruitment);
+            for (Recruitment recruitment : recruitments) {
+                recruitmentCacheService.pushNewRecruitment(recruitment);
             }
 
             //then
-            List<FindRecruitmentResponse> recruitments = recruitmentCacheService.findRecruitments();
-            assertThat(recruitments).hasSize(20);
-            recruitments.forEach(recruitment -> {
-                System.out.println(recruitment);
-            });
+            List<Long> recruitmentIdsDesc = recruitments.stream()
+                .map(Recruitment::getRecruitmentId)
+                .filter(i -> i > 80)
+                .sorted(Comparator.reverseOrder())
+                .toList();
+
+            List<FindRecruitmentResponse> findRecruitments
+                = recruitmentCacheService.findRecruitments();
+            assertThat(findRecruitments).hasSize(20);
+            assertThat(findRecruitments).map(FindRecruitmentResponse::recruitmentId)
+                .containsExactlyElementsOf(recruitmentIdsDesc);
         }
-
-
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentCacheServiceTest.java
@@ -1,0 +1,79 @@
+package com.clova.anifriends.domain.recruitment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.clova.anifriends.base.BaseIntegrationTest;
+import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
+import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecruitmentCacheServiceTest extends BaseIntegrationTest {
+
+    @Autowired
+    RecruitmentCacheService recruitmentCacheService;
+
+    @Nested
+    class RegisterRecruitmentTest {
+
+        Shelter shelter;
+
+        @BeforeEach
+        void setUp() {
+            shelter = ShelterFixture.shelter();
+            shelterRepository.save(shelter);
+        }
+
+        @Test
+        void registerRecruitment() {
+            //given
+            Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+
+            //when
+            recruitmentCacheService.registerRecruitment(recruitment);
+
+            //then
+            List<FindRecruitmentResponse> recruitments = recruitmentCacheService.findRecruitments();
+            assertThat(recruitments).hasSize(1);
+        }
+
+        @Test
+        void overflowTest() {
+            //given
+            List<Recruitment> list = new ArrayList<>();
+            for (int i = 0; i < 30; i++) {
+                Recruitment recruitmented = RecruitmentFixture.recruitment(shelter);
+                recruitmentRepository.save(recruitmented);
+                list.add(recruitmented);
+            }
+            int i = 1;
+            for (Recruitment recruitment : list) {
+                ReflectionTestUtils.setField(recruitment, "createdAt", LocalDateTime.now().plusHours(i));
+                i++;
+            }
+
+            //when
+            for (Recruitment recruitment : list) {
+                recruitmentCacheService.registerRecruitment(recruitment);
+            }
+
+            //then
+            List<FindRecruitmentResponse> recruitments = recruitmentCacheService.findRecruitments();
+            assertThat(recruitments).hasSize(20);
+            recruitments.forEach(recruitment -> {
+                System.out.println(recruitment);
+            });
+        }
+
+
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -206,81 +206,155 @@ class RecruitmentServiceTest {
             shelter = ShelterFixture.shelter();
         }
 
-        @Test
-        @DisplayName("성공")
-        void findRecruitments() {
-            //give
-            String keyword = "keyword";
-            LocalDate startDate = LocalDate.now();
-            LocalDate endDate = LocalDate.now();
-            String isClosed = "IS_CLOSED";
-            boolean title = false;
-            boolean content = false;
-            boolean shelterName = false;
-            LocalDateTime createdAt = LocalDateTime.now();
-            Long recruitmentId = 1L;
-            PageRequest pageRequest = PageRequest.of(0, 10);
-            Recruitment recruitment = recruitment(shelter);
-            ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
-            SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+        @Nested
+        @DisplayName("검색 조건이 하나라도 주어진 경우")
+        class WithCondition {
 
-            given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
-                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
-                title, content, shelterName, createdAt, recruitmentId, pageRequest)).willReturn(
-                recruitments);
-            given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
-                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(),
-                title, content, shelterName)).willReturn(Long.valueOf(recruitments.getSize()));
+            String keyword;
+            LocalDate startDate;
+            LocalDate endDate;
+            Boolean isClosed;
+            boolean titleContains;
+            boolean contentContains;
+            boolean shelterNameContains;
+            LocalDateTime createdAt;
+            Long recruitmentId;
 
-            //when
-            FindRecruitmentsResponse recruitmentsByVolunteer
-                = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
-                RecruitmentStatusFilter.valueOf(isClosed).getIsClosed(), title, content,
-                shelterName, createdAt, recruitmentId, pageRequest);
+            @BeforeEach
+            void setUp() {
+                keyword = null;
+                startDate = null;
+                endDate = null;
+                isClosed = null;
+                titleContains = true;
+                contentContains = true;
+                shelterNameContains = true;
+                createdAt = null;
+                recruitmentId = null;
+            }
 
-            //then
-            PageInfo pageInfo = recruitmentsByVolunteer.pageInfo();
-            assertThat(pageInfo.totalElements()).isEqualTo(recruitments.getSize());
-            FindRecruitmentResponse findRecruitment = recruitmentsByVolunteer.recruitments()
-                .get(0);
-            assertThat(findRecruitment.recruitmentTitle()).isEqualTo(recruitment.getTitle());
-            assertThat(findRecruitment.recruitmentStartTime()).isEqualTo(
-                recruitment.getStartTime());
-            assertThat(findRecruitment.recruitmentEndTime()).isEqualTo(recruitment.getEndTime());
-            assertThat(findRecruitment.recruitmentApplicantCount()).isEqualTo(
-                recruitment.getApplicantCount());
-            assertThat(findRecruitment.recruitmentCapacity()).isEqualTo(recruitment.getCapacity());
-            assertThat(findRecruitment.shelterName()).isEqualTo(recruitment.getShelter().getName());
-            assertThat(findRecruitment.shelterImageUrl())
-                .isEqualTo(recruitment.getShelter().getImage());
+            @Test
+            @DisplayName("성공: db에서 조회")
+            void findRecruitments() {
+                //give
+                startDate = LocalDate.now();
+                endDate = LocalDate.now();
+                PageRequest pageRequest = PageRequest.of(0, 10);
+                Recruitment recruitment = recruitment(shelter);
+                ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+                SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+                given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains, createdAt, recruitmentId, pageRequest))
+                    .willReturn(recruitments);
+                given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains))
+                    .willReturn(Long.valueOf(recruitments.getSize()));
+
+                //when
+                FindRecruitmentsResponse recruitmentsByVolunteer
+                    = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains, createdAt, recruitmentId, pageRequest);
+
+                //then
+                PageInfo pageInfo = recruitmentsByVolunteer.pageInfo();
+                assertThat(pageInfo.totalElements()).isEqualTo(recruitments.getSize());
+                FindRecruitmentResponse findRecruitment = recruitmentsByVolunteer.recruitments()
+                    .get(0);
+                assertThat(findRecruitment.recruitmentTitle()).isEqualTo(recruitment.getTitle());
+                assertThat(findRecruitment.recruitmentStartTime()).isEqualTo(
+                    recruitment.getStartTime());
+                assertThat(findRecruitment.recruitmentEndTime()).isEqualTo(recruitment.getEndTime());
+                assertThat(findRecruitment.recruitmentApplicantCount()).isEqualTo(
+                    recruitment.getApplicantCount());
+                assertThat(findRecruitment.recruitmentCapacity()).isEqualTo(recruitment.getCapacity());
+                assertThat(findRecruitment.shelterName()).isEqualTo(recruitment.getShelter().getName());
+                assertThat(findRecruitment.shelterImageUrl())
+                    .isEqualTo(recruitment.getShelter().getImage());
+            }
+
+            @Test
+            @DisplayName("성공: db에서 조회")
+            void findRecruitmentsWithOtherConditions() {
+                //given
+                keyword = "keyword";
+                isClosed = true;
+                titleContains = true;
+                contentContains = false;
+                shelterNameContains = false;
+                PageRequest pageRequest = PageRequest.of(0, 10);
+                Recruitment recruitment = recruitment(shelter);
+                ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+                SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+                given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains, createdAt,
+                    recruitmentId, pageRequest))
+                    .willReturn(recruitments);
+                given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains))
+                    .willReturn(Long.valueOf(recruitments.getSize()));
+
+                //when
+                FindRecruitmentsResponse recruitmentsByVolunteer
+                    = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains, createdAt,
+                    recruitmentId, pageRequest);
+
+                //then
+                then(recruitmentRepository).should()
+                    .findRecruitmentsV2(keyword, startDate, endDate, isClosed, titleContains,
+                        contentContains, shelterNameContains, createdAt, recruitmentId,
+                        pageRequest);
+            }
+
+            @Test
+            @DisplayName("성공: db에서 조회")
+            void findRecruitmentsWithAnotherCondition() {
+                //given
+                keyword = "keyword";
+                recruitmentId = 1L;
+                createdAt = LocalDateTime.now();
+                PageRequest pageRequest = PageRequest.of(0, 10);
+                Recruitment recruitment = recruitment(shelter);
+                ReflectionTestUtils.setField(recruitment, "recruitmentId", recruitmentId);
+                SliceImpl<Recruitment> recruitments = new SliceImpl<>(List.of(recruitment));
+
+                given(recruitmentRepository.findRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains, createdAt,
+                    recruitmentId, pageRequest))
+                    .willReturn(recruitments);
+                given(recruitmentRepository.countFindRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains))
+                    .willReturn(Long.valueOf(recruitments.getSize()));
+
+                //when
+                FindRecruitmentsResponse recruitmentsByVolunteer
+                    = recruitmentService.findRecruitmentsV2(keyword, startDate, endDate,
+                    isClosed, titleContains, contentContains, shelterNameContains, createdAt,
+                    recruitmentId, pageRequest);
+
+                //then
+                then(recruitmentRepository).should()
+                    .findRecruitmentsV2(keyword, startDate, endDate, isClosed, titleContains,
+                        contentContains, shelterNameContains, createdAt, recruitmentId,
+                        pageRequest);
+            }
         }
 
         @Nested
         @DisplayName("검색 조건이 주어지지 않은 경우")
-        class FindWithoutConditionTest {
+        class WithoutCondition {
 
-            String nullKeyword = null;
-            LocalDate nullStartDate = null;
-            LocalDate nullEndDate = null;
-            Boolean nullIsClosed = null;
-            boolean trueTitleContains = true;
-            boolean trueContentContains = true;
-            boolean trueShelterNameContains = true;
-            LocalDateTime nullCreatedAt = null;
-            Long nullRecruitmentId = null;
-
-            @BeforeEach
-            void setUp() {
-                nullKeyword = null;
-                nullStartDate = null;
-                nullEndDate = null;
-                nullIsClosed = null;
-                trueTitleContains = true;
-                trueContentContains = true;
-                trueShelterNameContains = true;
-                nullCreatedAt = null;
-                nullRecruitmentId = null;
-            }
+            final String nullKeyword = null;
+            final LocalDate nullStartDate = null;
+            final LocalDate nullEndDate = null;
+            final Boolean nullIsClosed = null;
+            final boolean trueTitleContains = true;
+            final boolean trueContentContains = true;
+            final boolean trueShelterNameContains = true;
+            final LocalDateTime nullCreatedAt = null;
+            final Long nullRecruitmentId = null;
 
             @Test
             @DisplayName("성공: 캐시된 봉사 모집글 목록 사이즈가 요청 사이즈를 초과하는 경우 캐시된 목록을 이용")

--- a/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/support/fixture/RecruitmentFixture.java
@@ -5,6 +5,7 @@ import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.shelter.Shelter;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class RecruitmentFixture {
@@ -29,6 +30,12 @@ public class RecruitmentFixture {
             DEADLINE,
             IMAGE_URL_LIST
         );
+    }
+
+    public static List<Recruitment> recruitments(Shelter shelter, int end) {
+        return IntStream.range(0, end)
+            .mapToObj(i -> recruitment(shelter))
+            .toList();
     }
 
     public static Recruitment recruitment(Shelter shelter, int capacity) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,7 +18,7 @@ spring:
         show_sql: true
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
 cloud:
   aws:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,7 +18,7 @@ spring:
         show_sql: true
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 cloud:
   aws:


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사 모집글 목록 첫 페이지를 캐싱하도록 로직을 구현하였습니다.
- 레디스 접근을 영속성 계층에서 발생하는 일이라 판단하여 RecruitmentCacheRepository로 이름지었습니다.
- 20개를 초과하는 요청이 들어오는 경우 20개까지의 데이터를 캐싱해서 반환합니다.
- 30개의 데이터를 캐싱하며 만일 캐싱된 데이터가 20개 이하인 경우 캐시 데이터를 신뢰하지 않고 db에서 조회를 수행합니다.
- 봉사 모집글이 생성, 수정, 삭제 되는 경우 캐시 데이터를 갱신합니다.
- 웜업의 경우 다른 캐시 로직이 머지된 후 추가하겠습니다.

### 📝 작업 요약
- RecruitmentCacheRepository 추가
- 봉사 모집글 생성, 업데이트, 삭제 시 캐시 갱신
- 봉사 모집글 목록 조회 시 캐시 데이터 이용

### 💡 관련 이슈
- close #309 
