### PR TITLE
fix: 보호 동물 목록 조회 dto 의 보호 동물 크기 파라미터명을 animalSize 로 변경한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/controller/AnimalController.java
@@ -66,7 +66,7 @@ public class AnimalController {
             findAnimalsByShelterRequest.gender(),
             findAnimalsByShelterRequest.neuteredFilter(),
             findAnimalsByShelterRequest.active(),
-            findAnimalsByShelterRequest.size(),
+            findAnimalsByShelterRequest.animalSize(),
             findAnimalsByShelterRequest.age(),
             pageable
         ));
@@ -83,7 +83,7 @@ public class AnimalController {
             findAnimalsRequest.neuteredFilter(),
             findAnimalsRequest.age(),
             findAnimalsRequest.gender(),
-            findAnimalsRequest.size(),
+            findAnimalsRequest.animalSize(),
             pageable
         ));
     }
@@ -99,7 +99,7 @@ public class AnimalController {
             findAnimalsByVolunteerRequestV2.neuteredFilter(),
             findAnimalsByVolunteerRequestV2.age(),
             findAnimalsByVolunteerRequestV2.gender(),
-            findAnimalsByVolunteerRequestV2.size(),
+            findAnimalsByVolunteerRequestV2.animalSize(),
             findAnimalsByVolunteerRequestV2.createdAt(),
             findAnimalsByVolunteerRequestV2.animalId(),
             pageable

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/FindAnimalsByVolunteerRequestV2.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/FindAnimalsByVolunteerRequestV2.java
@@ -13,7 +13,7 @@ public record FindAnimalsByVolunteerRequestV2(
     AnimalGender gender,
     AnimalNeuteredFilter neuteredFilter,
     AnimalActive active,
-    AnimalSize size,
+    AnimalSize animalSize,
     AnimalAge age,
     Long animalId,
     LocalDateTime createdAt

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/request/FindAnimalsByShelterRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/request/FindAnimalsByShelterRequest.java
@@ -13,7 +13,7 @@ public record FindAnimalsByShelterRequest(
     AnimalGender gender,
     AnimalNeuteredFilter neuteredFilter,
     AnimalActive active,
-    AnimalSize size,
+    AnimalSize animalSize,
     AnimalAge age
 ) {
 

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/request/FindAnimalsByVolunteerRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/request/FindAnimalsByVolunteerRequest.java
@@ -12,7 +12,7 @@ public record FindAnimalsByVolunteerRequest(
     AnimalGender gender,
     AnimalNeuteredFilter neuteredFilter,
     AnimalActive active,
-    AnimalSize size,
+    AnimalSize animalSize,
     AnimalAge age
 ) {
 

--- a/src/test/java/com/clova/anifriends/domain/animal/controller/AnimalControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/controller/AnimalControllerTest.java
@@ -173,10 +173,10 @@ class AnimalControllerTest extends BaseControllerTest {
         params.add("gender", AnimalGender.MALE.name());
         params.add("neuteredFilter", AnimalNeuteredFilter.IS_NEUTERED.name());
         params.add("active", "ACTIVE");
-        params.add("size", "SMALL");
+        params.add("animalSize", "SMALL");
         params.add("age", "BABY");
-        params.add("pageNumber", "0");
-        params.add("pageSize", "10");
+        params.add("page", "0");
+        params.add("size", "10");
 
         Long shelterId = 1L;
         Shelter shelter = shelter();
@@ -216,14 +216,14 @@ class AnimalControllerTest extends BaseControllerTest {
                     parameterWithName("active").description("보호 동물 성격").optional()
                         .attributes(DocumentationFormatGenerator.getConstraint(
                             "QUIET, NORMAL, ACTIVE, VERY_ACTIVE")),
-                    parameterWithName("size").description("보호 동물 크기").optional()
+                    parameterWithName("animalSize").description("보호 동물 크기").optional()
                         .attributes(
                             DocumentationFormatGenerator.getConstraint("SMALL, MEDIUM, LARGE")),
                     parameterWithName("age").description("보호 동물 나이").optional()
                         .attributes(DocumentationFormatGenerator.getConstraint(
                             "BABY, JUNIOR, ADULT, SENIOR")),
-                    parameterWithName("pageNumber").description("페이지 번호"),
-                    parameterWithName("pageSize").description("페이지 사이즈")
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("size").description("페이지 사이즈")
                 ),
                 responseFields(
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
@@ -252,10 +252,10 @@ class AnimalControllerTest extends BaseControllerTest {
         params.add("gender", AnimalGender.FEMALE.name());
         params.add("neuteredFilter", AnimalNeuteredFilter.IS_NEUTERED.name());
         params.add("active", AnimalActive.ACTIVE.name());
-        params.add("size", AnimalSize.SMALL.name());
+        params.add("animalSize", AnimalSize.SMALL.name());
         params.add("age", AnimalAge.ADULT.name());
-        params.add("pageNumber", String.valueOf(0));
-        params.add("pageSize", String.valueOf(10));
+        params.add("page", String.valueOf(0));
+        params.add("animalSize", String.valueOf(10));
 
         Shelter shelter = shelter();
         Animal animal = animal(shelter);
@@ -300,7 +300,7 @@ class AnimalControllerTest extends BaseControllerTest {
                         .attributes(DocumentationFormatGenerator.getConstraint(
                             String.join(", ", Arrays.stream(AnimalActive.values()).map(
                                 AnimalActive::name).toArray(String[]::new)))),
-                    parameterWithName("size").description("보호 동물 크기").optional()
+                    parameterWithName("animalSize").description("보호 동물 크기").optional()
                         .attributes(
                             DocumentationFormatGenerator.getConstraint(
                                 String.join(", ", Arrays.stream(AnimalSize.values()).map(
@@ -309,8 +309,8 @@ class AnimalControllerTest extends BaseControllerTest {
                         .attributes(DocumentationFormatGenerator.getConstraint(
                             String.join(", ", Arrays.stream(AnimalAge.values()).map(
                                 AnimalAge::name).toArray(String[]::new)))),
-                    parameterWithName("pageNumber").description("페이지 번호"),
-                    parameterWithName("pageSize").description("페이지 사이즈")
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("animalSize").description("페이지 사이즈")
                 ),
                 responseFields(
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
@@ -336,12 +336,12 @@ class AnimalControllerTest extends BaseControllerTest {
         params.add("gender", AnimalGender.FEMALE.name());
         params.add("neuteredFilter", AnimalNeuteredFilter.IS_NEUTERED.name());
         params.add("active", AnimalActive.ACTIVE.name());
-        params.add("size", AnimalSize.SMALL.name());
+        params.add("animalSize", AnimalSize.SMALL.name());
         params.add("age", AnimalAge.ADULT.name());
         params.add("animalId", String.valueOf(1L));
         params.add("createdAt", String.valueOf(LocalDateTime.now()));
-        params.add("pageNumber", String.valueOf(0));
-        params.add("pageSize", String.valueOf(10));
+        params.add("page", String.valueOf(0));
+        params.add("animalSize", String.valueOf(10));
 
         Shelter shelter = shelter();
         Animal animal = animal(shelter);
@@ -384,7 +384,7 @@ class AnimalControllerTest extends BaseControllerTest {
                         .attributes(DocumentationFormatGenerator.getConstraint(
                             String.join(", ", Arrays.stream(AnimalActive.values()).map(
                                 AnimalActive::name).toArray(String[]::new)))),
-                    parameterWithName("size").description("보호 동물 크기").optional()
+                    parameterWithName("animalSize").description("보호 동물 크기").optional()
                         .attributes(
                             DocumentationFormatGenerator.getConstraint(
                                 String.join(", ", Arrays.stream(AnimalSize.values()).map(
@@ -395,8 +395,8 @@ class AnimalControllerTest extends BaseControllerTest {
                                 AnimalAge::name).toArray(String[]::new)))),
                     parameterWithName("animalId").description("페이지 마지막 보호 동물 ID").optional(),
                     parameterWithName("createdAt").description("페이지 마지막 보호 동물 생일").optional(),
-                    parameterWithName("pageNumber").description("페이지 번호"),
-                    parameterWithName("pageSize").description("페이지 사이즈")
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("animalSize").description("페이지 사이즈")
                 ),
                 responseFields(
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalCacheServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalCacheServiceTest.java
@@ -299,7 +299,7 @@ class AnimalCacheServiceTest extends BaseIntegrationTest {
     class FindAnimalsTest {
 
         @Test
-        @DisplayName("성공: 30개 캐싱, size 20 -> 20개 반환")
+        @DisplayName("성공: 30개 캐싱, animalSize 20 -> 20개 반환")
         void findAnimals1() {
             // given
             Shelter shelter = ShelterFixture.shelter();
@@ -327,7 +327,7 @@ class AnimalCacheServiceTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("성공: 20개 캐싱, size 20 -> 20개 반환")
+        @DisplayName("성공: 20개 캐싱, animalSize 20 -> 20개 반환")
         void findAnimals2() {
             // given
             Shelter shelter = ShelterFixture.shelter();
@@ -354,7 +354,7 @@ class AnimalCacheServiceTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("성공: 10개 캐싱, size 20 -> 10개 반환")
+        @DisplayName("성공: 10개 캐싱, animalSize 20 -> 10개 반환")
         void findAnimals3() {
             // given
             Shelter shelter = ShelterFixture.shelter();
@@ -381,7 +381,7 @@ class AnimalCacheServiceTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("성공: 0개 캐싱, size 20 -> 0개 반환")
+        @DisplayName("성공: 0개 캐싱, animalSize 20 -> 0개 반환")
         void findAnimals4() {
             // given
             int animalCount = 0;


### PR DESCRIPTION
### ⛏ 작업 사항
보호 동물 목록 조회 dto 의 보호 동물 크기 파라미터명을 `animalSize` 로 변경한다.

### 📝 작업 요약
- 보호 동물 목록 조회 dto 의 보호 동물 크기 파라미터명을 `animalSize` 로 변경
- 기존의 페이지 네이션 변수 명을 `pageNumber` -> `page`, `pageSize` -> `size` 로 변경

### 💡 관련 이슈
- close #315 
