### PR TITLE
fix: 리프레시 토큰이 존재하지 않는 경우에 대한 예외를 추가한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/clova/anifriends/domain/auth/controller/AuthController.java
@@ -3,9 +3,12 @@ package com.clova.anifriends.domain.auth.controller;
 import com.clova.anifriends.domain.auth.dto.request.LoginRequest;
 import com.clova.anifriends.domain.auth.dto.response.LoginResponse;
 import com.clova.anifriends.domain.auth.dto.response.TokenResponse;
+import com.clova.anifriends.domain.auth.exception.AuthAuthenticationException;
 import com.clova.anifriends.domain.auth.service.AuthService;
+import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -64,8 +67,12 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<LoginResponse> refreshAccessToken(
-        @CookieValue(REFRESH_TOKEN_COOKIE) String refreshToken,
+        @CookieValue(value = REFRESH_TOKEN_COOKIE, required = false) String refreshToken,
         HttpServletResponse response) {
+        if(Objects.isNull(refreshToken)) {
+            throw new AuthAuthenticationException(ErrorCode.NOT_EXISTS_REFRESH_TOKEN,
+                "리프레시 토큰이 존재하지 않습니다.");
+        }
         TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken);
         addRefreshTokenCookie(response, tokenResponse);
         LoginResponse loginResponse = LoginResponse.from(tokenResponse);

--- a/src/main/java/com/clova/anifriends/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/clova/anifriends/domain/auth/controller/AuthController.java
@@ -55,9 +55,9 @@ public class AuthController {
             .from(REFRESH_TOKEN_COOKIE, tokenResponse.refreshToken())
             .path("/api/auth")
             .httpOnly(true)
-            // .secure(true) todo: https 적용 후 활성화할 것
+            .secure(true)
             .sameSite("None")
-            .domain("localhost")
+            .domain(".anifriends.site")
             .build();
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
     }

--- a/src/main/java/com/clova/anifriends/global/exception/ErrorCode.java
+++ b/src/main/java/com/clova/anifriends/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode implements EnumType {
     ACCESS_TOKEN_EXPIRED("AF101"), // 액세스 토큰 만료
     UN_AUTHENTICATION("AF102"), // 인증 안됨
     REFRESH_TOKEN_EXPIRED("AF103"), // 리프레시 토큰 만료
+    NOT_EXISTS_REFRESH_TOKEN("AF104"), // 리프레시 토큰 없음
     // 403
     UN_AUTHORIZATION("AF301"), // 권한 없음
     // 404


### PR DESCRIPTION
### ⛏ 작업 사항
- 리프레시 토큰이 존재하지 않는 경우의 적절한 예외 처리를 추가하였습니다.
  - 해당 상황에 대한 에러 코드를 추가하고 401 응답이 나가도록 구현하였습니다.
- 리프레시 토큰 쿠키에 secure 설정과 발급받은 도메인을 명시하였습니다.

### 📝 작업 요약
- 리프레시 토큰 쿠키가 없는 경우에 대한 예외 처리 추가

### 💡 관련 이슈
- close #317 
