### PR TITLE
chore: 프론트 봉사자 배포 주소를 추가한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/global/config/SecurityConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/SecurityConfig.java
@@ -27,10 +27,15 @@ import org.springframework.web.filter.CorsFilter;
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    private final String frontServer;
+    private final String frontVolunteerServer;
+    private final String frontShelterServer;
 
-    public SecurityConfig(@Value("${front.server}") String frontServer) {
-        this.frontServer = frontServer;
+    public SecurityConfig(
+        @Value("${front.volunteer.server}") String frontVolunteerServer,
+        @Value("${front.shelter.server}") String frontShelterServer
+    ) {
+        this.frontVolunteerServer = frontVolunteerServer;
+        this.frontShelterServer = frontShelterServer;
     }
 
     @Bean
@@ -67,7 +72,8 @@ public class SecurityConfig {
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(
-            List.of("http://localhost:5173", "http://localhost:5174", frontServer));
+            List.of("http://localhost:5173", "http://localhost:5174", frontShelterServer,
+                frontVolunteerServer));
         config.setAllowedMethods(
             List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowCredentials(true);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,8 @@
 front:
-  server: ThisIsJustTestFrontServerUrl
+  volunteer:
+    server: ThisIsJustTestFrontVolunteerServerUrl
+  shelter:
+    server: ThisIsJustTestFrontShelterServerUrl
 jwt:
   issuer: test
   expiry-seconds: 10000


### PR DESCRIPTION
### ⛏ 작업 사항
- 서브모듈에 front.volunteer.server를 추가했습니다.
- 서브모듈에서 기존에 front.server (보호소 주소)를 front.shelter.server로 변경했습니다.

### 📝 작업 요약
- 프론트 봉사자 배포 주소 추가

### 💡 관련 이슈
- close #341 
