### PR TITLE
refactor: 봉사자가 신청한 봉사 리스트 조회를 pagination 방식으로 변경한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/controller/ApplicantController.java
@@ -3,8 +3,8 @@ package com.clova.anifriends.domain.applicant.controller;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.request.UpdateApplicantStatusRequest;
 import com.clova.anifriends.domain.applicant.dto.request.UpdateApplicantsAttendanceRequest;
-import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.service.ApplicantService;
 import com.clova.anifriends.domain.applicant.service.dto.UpdateApplicantAttendanceCommand;
 import com.clova.anifriends.domain.auth.LoginUser;
@@ -12,6 +12,7 @@ import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import com.clova.anifriends.domain.auth.authorization.VolunteerOnly;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,10 +42,10 @@ public class ApplicantController {
     @VolunteerOnly
     @GetMapping("/volunteers/applicants")
     public ResponseEntity<FindApplyingVolunteersResponse> findApplyingVolunteers(
-        @LoginUser Long volunteerId
+        @LoginUser Long volunteerId,
+        Pageable pageable
     ) {
-        return ResponseEntity.ok(applicantService.findApplyingVolunteers(volunteerId));
-
+        return ResponseEntity.ok(applicantService.findApplyingVolunteers(volunteerId, pageable));
     }
 
     @ShelterOnly

--- a/src/main/java/com/clova/anifriends/domain/applicant/dto/response/FindApplyingVolunteersResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/dto/response/FindApplyingVolunteersResponse.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Page;
 
 public record FindApplyingVolunteersResponse(
     PageInfo pageInfo,
-    List<FindApplyingVolunteerResponse> findApplyingVolunteerResponses
+    List<FindApplyingVolunteerResponse> applicants
 ) {
 
     public record FindApplyingVolunteerResponse(

--- a/src/main/java/com/clova/anifriends/domain/applicant/dto/response/FindApplyingVolunteersResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/dto/response/FindApplyingVolunteersResponse.java
@@ -2,10 +2,13 @@ package com.clova.anifriends.domain.applicant.dto.response;
 
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
+import com.clova.anifriends.domain.common.PageInfo;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record FindApplyingVolunteersResponse(
+    PageInfo pageInfo,
     List<FindApplyingVolunteerResponse> findApplyingVolunteerResponses
 ) {
 
@@ -37,13 +40,14 @@ public record FindApplyingVolunteersResponse(
     }
 
     public static FindApplyingVolunteersResponse from(
-        List<Applicant> applicants
+        Page<Applicant> pagination
     ) {
-        return new FindApplyingVolunteersResponse(
-            applicants
-                .stream()
-                .map(FindApplyingVolunteerResponse::from)
-                .toList()
-        );
+        PageInfo pageInfo = PageInfo.of(pagination.getTotalElements(), pagination.hasNext());
+
+        List<FindApplyingVolunteerResponse> findApplyingVolunteerResponses = pagination.get()
+            .map(FindApplyingVolunteerResponse::from)
+            .toList();
+
+        return new FindApplyingVolunteersResponse(pageInfo, findApplyingVolunteerResponses);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
@@ -39,7 +39,7 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
         + "where r.recruitmentId = :recruitmentId "
         + "and s.shelterId = :shelterId "
         + "and (a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE "
-        + "or a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NO_SHOW)")
+        + "or a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW)")
     List<Applicant> findApprovedApplicants(
         @Param("recruitmentId") Long recruitmentId,
         @Param("shelterId") Long shelterId
@@ -61,7 +61,7 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
         + "and a.recruitment.shelter.shelterId = :shelterId "
         + "and a.applicantId in :ids "
         + "and (a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE "
-        + "or a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NO_SHOW)")
+        + "or a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW)")
     void updateBulkAttendance(
         @Param("shelterId") Long shelterId,
         @Param("recruitmentId") Long recruitmentId,

--- a/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
@@ -5,6 +5,8 @@ import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,8 +22,8 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
             + "left join fetch a.review "
             + "where a.volunteer = :volunteer"
     )
-    List<Applicant> findApplyingVolunteers(
-        @Param("volunteer") Volunteer volunteer);
+    Page<Applicant> findApplyingVolunteers(
+        @Param("volunteer") Volunteer volunteer, Pageable pageable);
 
     @Query("select a from Applicant a "
         + "where a.applicantId = :applicantId "

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -115,7 +115,7 @@ public class ApplicantService {
     private void updateAttendanceStatus(Long shelterId, Long recruitmentId, List<Long> noShowIds,
         List<Long> attendedIds) {
         applicantRepository.updateBulkAttendance(shelterId, recruitmentId, noShowIds,
-            ApplicantStatus.NO_SHOW);
+            ApplicantStatus.NOSHOW);
         applicantRepository.updateBulkAttendance(shelterId, recruitmentId, attendedIds,
             ApplicantStatus.ATTENDANCE);
     }

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -2,8 +2,8 @@ package com.clova.anifriends.domain.applicant.service;
 
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
-import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.applicant.service.dto.UpdateApplicantAttendanceCommand;
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,12 +59,13 @@ public class ApplicantService {
 
     @Transactional(readOnly = true)
     public FindApplyingVolunteersResponse findApplyingVolunteers(
-        Long volunteerId
+        Long volunteerId,
+        Pageable pageable
     ) {
         Volunteer foundVolunteer = getVolunteer(volunteerId);
 
-        List<Applicant> applyingVolunteers = applicantRepository.findApplyingVolunteers(
-            foundVolunteer);
+        Page<Applicant> applyingVolunteers = applicantRepository.findApplyingVolunteers(
+            foundVolunteer, pageable);
 
         return FindApplyingVolunteersResponse.from(applyingVolunteers);
     }

--- a/src/main/java/com/clova/anifriends/domain/applicant/vo/ApplicantStatus.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/vo/ApplicantStatus.java
@@ -7,7 +7,7 @@ public enum ApplicantStatus implements EnumType {
     PENDING,
     REFUSED,
     ATTENDANCE,
-    NO_SHOW,
+    NOSHOW,
     APPROVED,
     ;
 
@@ -17,7 +17,7 @@ public enum ApplicantStatus implements EnumType {
     }
 
     public ApplicantStatus convertToApprovalStatus() {
-        if (this == ApplicantStatus.ATTENDANCE || this == ApplicantStatus.NO_SHOW) {
+        if (this == ApplicantStatus.ATTENDANCE || this == ApplicantStatus.NOSHOW) {
             return ApplicantStatus.APPROVED;
         }
         return this;

--- a/src/main/java/com/clova/anifriends/domain/volunteer/repository/VolunteerRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/repository/VolunteerRepository.java
@@ -31,7 +31,7 @@ public interface VolunteerRepository extends JpaRepository<Volunteer, Long> {
         + "join fetch a.recruitment r "
         + "where r.shelter.shelterId = :shelterId "
         + "and r.recruitmentId = :recruitmentId "
-        + "and a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NO_SHOW "
+        + "and a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW "
         + "and a.applicantId in :attendedIds")
     List<Volunteer> findNoShowByAttendedIds(
         @Param("shelterId") Long shelterId,

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.applicant.controller;
 
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.PENDING;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -14,12 +15,14 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,8 +32,8 @@ import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.request.UpdateApplicantStatusRequest;
 import com.clova.anifriends.domain.applicant.dto.request.UpdateApplicantsAttendanceRequest;
 import com.clova.anifriends.domain.applicant.dto.request.UpdateApplicantsAttendanceRequest.UpdateApplicantAttendanceRequest;
-import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
@@ -43,6 +46,9 @@ import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -103,19 +109,22 @@ class ApplicantControllerTest extends BaseControllerTest {
         Review review = ReviewFixture.review(applicantShouldWriteReview);
         setField(review, "reviewId", 1L);
 
+        PageImpl<Applicant> applicants = new PageImpl<>(
+            List.of(applicantShouldWriteReview, applicantShouldNotWriteReview));
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
         FindApplyingVolunteersResponse findApplyingVolunteersResponse = FindApplyingVolunteersResponse.from(
-            List.of(
-                applicantShouldWriteReview,
-                applicantShouldNotWriteReview
-            )
+            applicants
         );
 
-        given(applicantService.findApplyingVolunteers(volunteerId)).willReturn(
+        given(applicantService.findApplyingVolunteers(anyLong(), any(Pageable.class))).willReturn(
             findApplyingVolunteersResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(
             get("/api/volunteers/applicants")
+                .param("pageNumber", "0")
+                .param("pageSize", "10")
                 .header(AUTHORIZATION, volunteerAccessToken)
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -125,7 +134,14 @@ class ApplicantControllerTest extends BaseControllerTest {
                 requestHeaders(
                     headerWithName(AUTHORIZATION).description("봉사자 액세스 토큰")
                 ),
+                queryParameters(
+                    parameterWithName("pageNumber").description("페이지 번호"),
+                    parameterWithName("pageSize").description("페이지 사이즈")
+                ),
                 responseFields(
+                    fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
+                    fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),
+                    fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부"),
                     fieldWithPath("findApplyingVolunteerResponses").type(JsonFieldType.ARRAY)
                         .description("신청한 봉사 리스트"),
                     fieldWithPath("findApplyingVolunteerResponses[].shelterId").type(

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -142,30 +142,30 @@ class ApplicantControllerTest extends BaseControllerTest {
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
                     fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),
                     fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부"),
-                    fieldWithPath("findApplyingVolunteerResponses").type(JsonFieldType.ARRAY)
+                    fieldWithPath("applicants").type(JsonFieldType.ARRAY)
                         .description("신청한 봉사 리스트"),
-                    fieldWithPath("findApplyingVolunteerResponses[].shelterId").type(
+                    fieldWithPath("applicants[].shelterId").type(
                             JsonFieldType.NUMBER)
                         .description("보호소 ID"),
-                    fieldWithPath("findApplyingVolunteerResponses[].recruitmentId").type(
+                    fieldWithPath("applicants[].recruitmentId").type(
                             JsonFieldType.NUMBER)
                         .description("봉사 모집글 ID"),
-                    fieldWithPath("findApplyingVolunteerResponses[].applicantId").type(
+                    fieldWithPath("applicants[].applicantId").type(
                             JsonFieldType.NUMBER)
                         .description("봉사 신청자 ID"),
-                    fieldWithPath("findApplyingVolunteerResponses[].recruitmentTitle").type(
+                    fieldWithPath("applicants[].recruitmentTitle").type(
                             JsonFieldType.STRING)
                         .description("모집글 제목"),
-                    fieldWithPath("findApplyingVolunteerResponses[].shelterName").type(
+                    fieldWithPath("applicants[].shelterName").type(
                             JsonFieldType.STRING)
                         .description("보호소 이름"),
-                    fieldWithPath("findApplyingVolunteerResponses[].applicantStatus").type(
+                    fieldWithPath("applicants[].applicantStatus").type(
                             JsonFieldType.STRING)
                         .description("승인 상태"),
-                    fieldWithPath("findApplyingVolunteerResponses[].applicantIsWritedReview").type(
+                    fieldWithPath("applicants[].applicantIsWritedReview").type(
                             JsonFieldType.BOOLEAN)
                         .description("후기 작성 가능 여부"),
-                    fieldWithPath("findApplyingVolunteerResponses[].recruitmentStartTime").type(
+                    fieldWithPath("applicants[].recruitmentStartTime").type(
                             JsonFieldType.STRING)
                         .description("봉사 날짜")
                 )

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -2,7 +2,7 @@ package com.clova.anifriends.domain.applicant.repository;
 
 import static com.clova.anifriends.domain.applicant.support.ApplicantFixture.applicant;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE;
-import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NO_SHOW;
+import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.PENDING;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.REFUSED;
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture.recruitment;
@@ -51,7 +51,7 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
 
             Recruitment recruitment = recruitment(shelter);
             Applicant applicantAttendance = applicant(recruitment, volunteerAttendance, ATTENDANCE);
-            Applicant applicantNoShow = applicant(recruitment, volunteerNoShow, NO_SHOW);
+            Applicant applicantNoShow = applicant(recruitment, volunteerNoShow, NOSHOW);
             Applicant applicantPending = applicant(recruitment, volunteerPending, PENDING);
             Applicant applicantRefused = applicant(recruitment, volunteerRefused, REFUSED);
 
@@ -173,7 +173,7 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             Volunteer volunteerRefused = volunteer();
 
             Applicant applicantAttendance = applicant(recruitment, volunteerAttendance, ATTENDANCE);
-            Applicant applicantNoShow = applicant(recruitment, volunteerNoShow, NO_SHOW);
+            Applicant applicantNoShow = applicant(recruitment, volunteerNoShow, NOSHOW);
             Applicant applicantPending = applicant(recruitment, volunteerPending, PENDING);
             Applicant applicantRefused = applicant(recruitment, volunteerRefused, REFUSED);
 
@@ -221,7 +221,7 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             Applicant applicantAttendanceToNoShow = applicant(recruitment,
                 volunteerAttendanceToNoShow, ATTENDANCE);
             Applicant applicantNoShowToAttendance = applicant(recruitment,
-                volunteerNoShowToAttendance, NO_SHOW);
+                volunteerNoShowToAttendance, NOSHOW);
             Applicant applicantPending = applicant(recruitment, volunteerPending, PENDING);
             Applicant applicantRefused = applicant(recruitment, volunteerRefuse, REFUSED);
 
@@ -245,7 +245,7 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             applicantRepository.updateBulkAttendance(shelter.getShelterId(),
                 recruitment.getRecruitmentId(), attendedIds, ATTENDANCE);
             applicantRepository.updateBulkAttendance(shelter.getShelterId(),
-                recruitment.getRecruitmentId(), noShowIds, NO_SHOW);
+                recruitment.getRecruitmentId(), noShowIds, NOSHOW);
 
             entityManager.flush();
             entityManager.clear();
@@ -260,7 +260,7 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             Optional<Applicant> persistedApplicantAttendanceToNoShow = applicantRepository.findById(
                 applicantAttendanceToNoShow.getApplicantId());
             assertThat(persistedApplicantAttendanceToNoShow).isNotEmpty();
-            assertThat(persistedApplicantAttendanceToNoShow.get().getStatus()).isEqualTo(NO_SHOW);
+            assertThat(persistedApplicantAttendanceToNoShow.get().getStatus()).isEqualTo(NOSHOW);
 
             Optional<Applicant> persistedApplicantPending = applicantRepository.findById(
                 applicantPending.getApplicantId());

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 class ApplicantRepositoryTest extends BaseRepositoryTest {
 
@@ -135,9 +137,11 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             applicantRepository.save(applicantShouldNotWriteReview1);
             applicantRepository.save(applicantShouldNotWriteReview2);
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
             // when
-            List<Applicant> applyingVolunteers = applicantRepository.findApplyingVolunteers(
-                volunteer);
+            Page<Applicant> applyingVolunteers = applicantRepository.findApplyingVolunteers(
+                volunteer, pageRequest);
 
             FindApplyingVolunteersResponse expected = FindApplyingVolunteersResponse.from(
                 applyingVolunteers);

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -147,11 +147,11 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
                 applyingVolunteers);
 
             // then
-            assertThat(expected.findApplyingVolunteerResponses().get(0)
+            assertThat(expected.applicants().get(0)
                 .applicantIsWritedReview()).isTrue();
-            assertThat(expected.findApplyingVolunteerResponses().get(1)
+            assertThat(expected.applicants().get(1)
                 .applicantIsWritedReview()).isFalse();
-            assertThat(expected.findApplyingVolunteerResponses().get(2)
+            assertThat(expected.applicants().get(2)
                 .applicantIsWritedReview()).isFalse();
         }
     }

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -21,8 +21,8 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
-import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.applicant.service.dto.UpdateApplicantAttendanceCommand;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
@@ -50,6 +50,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -209,6 +212,7 @@ class ApplicantServiceTest {
         @DisplayName("성공 : 후기 작성자가 1명인 경우")
         void findApplyingVolunteers1() {
             // given
+            long volunteerId = 1L;
             Volunteer volunteer = VolunteerFixture.volunteer();
             Shelter shelter = ShelterFixture.shelter();
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
@@ -217,18 +221,22 @@ class ApplicantServiceTest {
             Applicant applicantShouldNotWriteReview = ApplicantFixture.applicant(
                 recruitment,
                 volunteer, PENDING);
+            PageImpl<Applicant> applicants = new PageImpl<>(
+                List.of(applicantShouldWriteReview, applicantShouldNotWriteReview));
 
             FindApplyingVolunteersResponse findApplyingVolunteersResponse = FindApplyingVolunteersResponse.from(
-                List.of(applicantShouldWriteReview, applicantShouldNotWriteReview)
+                applicants
             );
+            PageRequest pageRequest = PageRequest.of(0, 10);
 
             given(volunteerRepository.findById(anyLong())).willReturn(Optional.of(volunteer));
-            given(applicantRepository.findApplyingVolunteers(any())).willReturn(
-                List.of(applicantShouldWriteReview, applicantShouldNotWriteReview));
+            given(
+                applicantRepository.findApplyingVolunteers(any(), any(Pageable.class))).willReturn(
+                applicants);
 
             // when
             FindApplyingVolunteersResponse foundApplyingVolunteers = applicantService.findApplyingVolunteers(
-                anyLong());
+                volunteerId, pageRequest);
 
             // then
             assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(0)
@@ -245,6 +253,7 @@ class ApplicantServiceTest {
         @DisplayName("성공 : 후기 작성자가 0명인 경우")
         void findApplyingVolunteers2() {
             // given
+            long volunteerId = 1L;
             Volunteer volunteer = VolunteerFixture.volunteer();
             Shelter shelter = ShelterFixture.shelter();
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
@@ -255,18 +264,23 @@ class ApplicantServiceTest {
                 recruitment,
                 volunteer, PENDING);
 
-            given(volunteerRepository.findById(anyLong())).willReturn(Optional.of(volunteer));
+            PageImpl<Applicant> applicants = new PageImpl<>(
+                List.of(applicantShouldWriteReview, applicantShouldNotWriteReview));
 
             FindApplyingVolunteersResponse findApplyingVolunteersResponse = FindApplyingVolunteersResponse.from(
-                List.of(applicantShouldWriteReview, applicantShouldNotWriteReview)
+                applicants
             );
+            PageRequest pageRequest = PageRequest.of(0, 10);
 
-            given(applicantRepository.findApplyingVolunteers(any())).willReturn(
-                List.of(applicantShouldWriteReview, applicantShouldNotWriteReview));
+            given(volunteerRepository.findById(anyLong())).willReturn(Optional.of(volunteer));
+            given(volunteerRepository.findById(anyLong())).willReturn(Optional.of(volunteer));
+            given(
+                applicantRepository.findApplyingVolunteers(any(), any(Pageable.class))).willReturn(
+                applicants);
 
             // when
             FindApplyingVolunteersResponse foundApplyingVolunteers = applicantService.findApplyingVolunteers(
-                anyLong());
+                volunteerId, pageRequest);
 
             // then
             assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(0)

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -239,13 +239,13 @@ class ApplicantServiceTest {
                 volunteerId, pageRequest);
 
             // then
-            assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(0)
+            assertThat(foundApplyingVolunteers.applicants().get(0)
                 .applicantIsWritedReview()).isEqualTo(
-                findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(0)
+                findApplyingVolunteersResponse.applicants().get(0)
                     .applicantIsWritedReview());
-            assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(1)
+            assertThat(foundApplyingVolunteers.applicants().get(1)
                 .applicantIsWritedReview()).isEqualTo(
-                findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(1)
+                findApplyingVolunteersResponse.applicants().get(1)
                     .applicantIsWritedReview());
         }
 
@@ -283,13 +283,13 @@ class ApplicantServiceTest {
                 volunteerId, pageRequest);
 
             // then
-            assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(0)
+            assertThat(foundApplyingVolunteers.applicants().get(0)
                 .applicantIsWritedReview()).isEqualTo(
-                findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(0)
+                findApplyingVolunteersResponse.applicants().get(0)
                     .applicantIsWritedReview());
-            assertThat(foundApplyingVolunteers.findApplyingVolunteerResponses().get(1)
+            assertThat(foundApplyingVolunteers.applicants().get(1)
                 .applicantIsWritedReview()).isEqualTo(
-                findApplyingVolunteersResponse.findApplyingVolunteerResponses().get(1)
+                findApplyingVolunteersResponse.applicants().get(1)
                     .applicantIsWritedReview());
         }
     }

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -2,7 +2,7 @@ package com.clova.anifriends.domain.applicant.service;
 
 import static com.clova.anifriends.domain.applicant.support.ApplicantFixture.applicant;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE;
-import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NO_SHOW;
+import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.PENDING;
 import static com.clova.anifriends.domain.applicant.vo.ApplicantStatus.REFUSED;
 import static com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture.recruitment;
@@ -312,7 +312,7 @@ class ApplicantServiceTest {
             Applicant applicantRefused = ApplicantFixture.applicant(recruitment, volunteer,
                 REFUSED);
             Applicant applicantPended = ApplicantFixture.applicant(recruitment, volunteer, PENDING);
-            Applicant applicantNoShow = ApplicantFixture.applicant(recruitment, volunteer, NO_SHOW);
+            Applicant applicantNoShow = ApplicantFixture.applicant(recruitment, volunteer, NOSHOW);
 
             FindApplicantsResponse response = FindApplicantsResponse.from(
                 List.of(applicantAttended, applicantRefused, applicantPended, applicantNoShow),
@@ -354,9 +354,9 @@ class ApplicantServiceTest {
             Applicant applicantAttendanceToNoShow = ApplicantFixture.applicant(recruitment,
                 volunteer2, ATTENDANCE, 2L);
             Applicant applicantNoShowToAttendance = ApplicantFixture.applicant(recruitment,
-                volunteer3, NO_SHOW, 3L);
+                volunteer3, NOSHOW, 3L);
             Applicant applicantNoShow = ApplicantFixture.applicant(recruitment, volunteer4,
-                NO_SHOW, 4L);
+                NOSHOW, 4L);
 
             UpdateApplicantAttendanceCommand command1 = new UpdateApplicantAttendanceCommand(
                 applicantAttendance.getApplicantId(), true);
@@ -383,7 +383,7 @@ class ApplicantServiceTest {
             verify(applicantRepository, times(1))
                 .updateBulkAttendance(shelter.getShelterId(), recruitment.getRecruitmentId(),
                     List.of(applicantAttendanceToNoShow.getApplicantId(),
-                        applicantNoShow.getApplicantId()), NO_SHOW);
+                        applicantNoShow.getApplicantId()), NOSHOW);
 
             verify(volunteerNotificationRepository, times(1))
                 .saveAll(any(List.class));


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자가 신청한 봉사 리스트 조회 API를 Pagenation 방식으로 변경했습니다.

### 📝 작업 요약
- 봉사자가 신청한 봉사 리스트 조회를 pagination 방식으로 변경

### 💡 관련 이슈
- close #357 
