### PR TITLE
refactor: 보호 동물 조회 api 에서 발생한 N+1 문제를 해결한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/animal/Animal.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/Animal.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "animal")
@@ -83,6 +84,7 @@ public class Animal extends BaseTimeEntity {
     @Embedded
     private AnimalAdopted adopted = new AnimalAdopted(IS_ADOPTED_DEFAULT);
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "animal", cascade = CascadeType.PERSIST,
         fetch = FetchType.LAZY, orphanRemoval = true)
     private List<AnimalImage> images = new ArrayList<>();

--- a/src/main/java/com/clova/anifriends/domain/animal/dto/response/FindAnimalsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/dto/response/FindAnimalsResponse.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.animal.dto.response;
 
 import com.clova.anifriends.domain.animal.Animal;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
 import com.clova.anifriends.domain.common.PageInfo;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -29,6 +30,16 @@ public record FindAnimalsResponse(
             );
         }
 
+        public static FindAnimalResponse from(FindAnimalsResult animal) {
+            return new FindAnimalResponse(
+                animal.getAnimalId(),
+                animal.getAnimalName(),
+                animal.getShelterName(),
+                animal.getShelterAddress(),
+                animal.getAnimalImageUrl()
+            );
+        }
+
     }
 
     public static FindAnimalsResponse from(Page<Animal> pagination) {
@@ -39,7 +50,8 @@ public record FindAnimalsResponse(
         return new FindAnimalsResponse(pageInfo, findAnimalByVolunteerResponses);
     }
 
-    public static FindAnimalsResponse fromV2(Slice<Animal> animalsWithPagination, Long count) {
+    public static FindAnimalsResponse fromV2(Slice<FindAnimalsResult> animalsWithPagination,
+        Long count) {
         PageInfo pageInfo = PageInfo.of(count, animalsWithPagination.hasNext());
         List<FindAnimalResponse> findAnimalsResponses = animalsWithPagination.get()
             .map(FindAnimalResponse::from).toList();

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalCacheRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalCacheRepository.java
@@ -35,7 +35,6 @@ public class AnimalCacheRepository {
     public static final double NANO = 1_000_000_000.0;
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final RedisTemplate<String, Long> countRedisTemplate;
     private final AnimalRepository animalRepository;
 
     private ZSetOperations<String, Object> zSetOperations;

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepository.java
@@ -23,4 +23,9 @@ public interface AnimalRepository extends JpaRepository<Animal, Long>, AnimalRep
         @Param("animalId") Long animalId,
         @Param("shelterId") Long shelterId);
 
+    @Query("select a from Animal a"
+        + " join fetch a.images"
+        + " where a.animalId = :animalId")
+    Optional<Animal> findByAnimalIdWithImages(@Param("animalId") Long animalId);
+
 }

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryCustom.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.animal.repository;
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.AnimalAge;
 import com.clova.anifriends.domain.animal.AnimalSize;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
 import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
 import com.clova.anifriends.domain.animal.vo.AnimalNeuteredFilter;
@@ -36,7 +37,7 @@ public interface AnimalRepositoryCustom {
         Pageable pageable
     );
 
-    Slice<Animal> findAnimalsV2(
+    Slice<FindAnimalsResult> findAnimalsV2(
         AnimalType type,
         AnimalActive active,
         AnimalNeuteredFilter neuteredFilter,

--- a/src/main/java/com/clova/anifriends/domain/animal/repository/response/FindAnimalsResult.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/repository/response/FindAnimalsResult.java
@@ -1,0 +1,33 @@
+package com.clova.anifriends.domain.animal.repository.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class FindAnimalsResult {
+
+    private final Long animalId;
+    private final String animalName;
+    private final LocalDateTime createdAt;
+    private final String shelterName;
+    private final String shelterAddress;
+    private final String animalImageUrl;
+
+    @QueryProjection
+    public FindAnimalsResult(
+        Long animalId,
+        String animalName,
+        LocalDateTime createdAt,
+        String shelterName,
+        String shelterAddress,
+        String animalImageUrl
+    ) {
+        this.animalId = animalId;
+        this.animalName = animalName;
+        this.createdAt = createdAt;
+        this.shelterName = shelterName;
+        this.shelterAddress = shelterAddress;
+        this.animalImageUrl = animalImageUrl;
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
@@ -120,7 +120,8 @@ public class AnimalService {
     ) {
 
         if (isFirstPage(type, active, neuteredFilter, age, gender, size, createdAt, animalId)) {
-            return animalCacheRepository.findAnimals(pageable.getPageSize(), animalCacheRepository.getTotalNumberOfAnimals());
+            return animalCacheRepository.findAnimals(pageable.getPageSize(),
+                animalCacheRepository.getTotalNumberOfAnimals());
         }
 
         long count = animalRepository.countAnimalsV2(
@@ -154,7 +155,7 @@ public class AnimalService {
         if (isAdopted == true) {
             animalCacheRepository.deleteAnimal(animal);
             animalCacheRepository.decreaseTotalNumberOfAnimals();
-        }         
+        }
     }
 
     @Transactional
@@ -206,7 +207,7 @@ public class AnimalService {
     }
 
     private Animal getAnimalByAnimalId(Long animalId) {
-        return animalRepository.findById(animalId)
+        return animalRepository.findByAnimalIdWithImages(animalId)
             .orElseThrow(() -> new AnimalNotFoundException("존재하지 않는 보호 동물입니다."));
     }
 

--- a/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
+++ b/src/main/java/com/clova/anifriends/domain/animal/service/AnimalService.java
@@ -12,6 +12,7 @@ import com.clova.anifriends.domain.animal.exception.AnimalNotFoundException;
 import com.clova.anifriends.domain.animal.mapper.AnimalMapper;
 import com.clova.anifriends.domain.animal.repository.AnimalCacheRepository;
 import com.clova.anifriends.domain.animal.repository.AnimalRepository;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
 import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
 import com.clova.anifriends.domain.animal.vo.AnimalNeuteredFilter;
@@ -133,7 +134,7 @@ public class AnimalService {
             size
         );
 
-        Slice<Animal> animalsWithPagination = animalRepository.findAnimalsV2(
+        Slice<FindAnimalsResult> animalsWithPagination = animalRepository.findAnimalsV2(
             type,
             active,
             neuteredFilter,

--- a/src/test/java/com/clova/anifriends/domain/animal/controller/AnimalControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/controller/AnimalControllerTest.java
@@ -40,6 +40,8 @@ import com.clova.anifriends.domain.animal.dto.response.FindAnimalDetail;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsByShelterResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsResponse;
 import com.clova.anifriends.domain.animal.dto.response.RegisterAnimalResponse;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
+import com.clova.anifriends.domain.animal.support.fixture.AnimalDtoFixture;
 import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
 import com.clova.anifriends.domain.animal.vo.AnimalNeuteredFilter;
@@ -346,9 +348,9 @@ class AnimalControllerTest extends BaseControllerTest {
         Shelter shelter = shelter();
         Animal animal = animal(shelter);
         ReflectionTestUtils.setField(animal, "animalId", 1L);
-
+        FindAnimalsResult findAnimalsResult = AnimalDtoFixture.findAnimalsResult(animal);
         FindAnimalsResponse response = FindAnimalsResponse
-            .fromV2(new SliceImpl<>(List.of(animal)), 1L);
+            .fromV2(new SliceImpl<>(List.of(findAnimalsResult)), 1L);
 
         when(animalService.findAnimalsV2(
             any(AnimalType.class),

--- a/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
@@ -715,8 +715,6 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
             shelterRepository.save(shelter);
             animalRepository.saveAll(List.of(matchAnimal1, matchAnimal2, disMatchAnimal1));
 
-            PageRequest pageRequest = PageRequest.of(0, 10);
-
             // when
             Long result = animalRepository.countAnimalsV2(
                 typeFilter,

--- a/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
@@ -6,6 +6,8 @@ import com.clova.anifriends.base.BaseRepositoryTest;
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.AnimalAge;
 import com.clova.anifriends.domain.animal.AnimalSize;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
+import com.clova.anifriends.domain.animal.support.fixture.AnimalDtoFixture;
 import com.clova.anifriends.domain.animal.support.fixture.AnimalFixture;
 import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
@@ -559,9 +561,11 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
             animalRepository.saveAll(List.of(matchAnimal1, matchAnimal2, disMatchAnimal1));
 
             PageRequest pageRequest = PageRequest.of(0, 10);
+            FindAnimalsResult findAnimalsResult1 = AnimalDtoFixture.findAnimalsResult(matchAnimal1);
+            FindAnimalsResult findAnimalsResult2 = AnimalDtoFixture.findAnimalsResult(matchAnimal2);
 
             // when
-            Slice<Animal> result = animalRepository.findAnimalsV2(
+            Slice<FindAnimalsResult> result = animalRepository.findAnimalsV2(
                 typeFilter,
                 activeFilter,
                 neuteredFilter,
@@ -575,7 +579,8 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
 
             // then
             assertThat(result.hasNext()).isFalse();
-            assertThat(result.getContent()).containsExactlyInAnyOrder(matchAnimal1, matchAnimal2);
+            assertThat(result.getContent()).usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(findAnimalsResult1, findAnimalsResult2);
         }
 
         @Test
@@ -628,9 +633,11 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
             animalRepository.saveAll(List.of(matchAnimal1, matchAnimal2));
 
             PageRequest pageRequest = PageRequest.of(0, 10);
+            FindAnimalsResult findAnimalsResult1 = AnimalDtoFixture.findAnimalsResult(matchAnimal1);
+            FindAnimalsResult findAnimalsResult2 = AnimalDtoFixture.findAnimalsResult(matchAnimal2);
 
             // when
-            Slice<Animal> result = animalRepository.findAnimalsV2(
+            Slice<FindAnimalsResult> result = animalRepository.findAnimalsV2(
                 nullTypeFilter,
                 nullActiveFilter,
                 nullIsNeuteredFilter,
@@ -644,7 +651,9 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
 
             // then
             assertThat(result.hasNext()).isFalse();
-            assertThat(result.getContent()).containsExactlyInAnyOrder(matchAnimal1, matchAnimal2);
+            assertThat(result.getContent()).usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(findAnimalsResult1,
+                    findAnimalsResult2);
         }
     }
 

--- a/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
@@ -579,8 +579,11 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
 
             // then
             assertThat(result.hasNext()).isFalse();
-            assertThat(result.getContent()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(findAnimalsResult1, findAnimalsResult2);
+            assertThat(result.getNumberOfElements()).isEqualTo(2);
+            assertThat(result.getContent().get(0)).usingRecursiveComparison()
+                .isEqualTo(findAnimalsResult2);
+            assertThat(result.getContent().get(1)).usingRecursiveComparison()
+                .isEqualTo(findAnimalsResult1);
         }
 
         @Test
@@ -651,9 +654,11 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
 
             // then
             assertThat(result.hasNext()).isFalse();
-            assertThat(result.getContent()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(findAnimalsResult1,
-                    findAnimalsResult2);
+            assertThat(result.getNumberOfElements()).isEqualTo(2);
+            assertThat(result.getContent().get(0)).usingRecursiveComparison()
+                .isEqualTo(findAnimalsResult2);
+            assertThat(result.getContent().get(1)).usingRecursiveComparison()
+                .isEqualTo(findAnimalsResult1);
         }
     }
 

--- a/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/repository/AnimalRepositoryTest.java
@@ -581,8 +581,10 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
             assertThat(result.hasNext()).isFalse();
             assertThat(result.getNumberOfElements()).isEqualTo(2);
             assertThat(result.getContent().get(0)).usingRecursiveComparison()
+                .ignoringFields("createdAt")
                 .isEqualTo(findAnimalsResult2);
             assertThat(result.getContent().get(1)).usingRecursiveComparison()
+                .ignoringFields("createdAt")
                 .isEqualTo(findAnimalsResult1);
         }
 
@@ -656,8 +658,10 @@ public class AnimalRepositoryTest extends BaseRepositoryTest {
             assertThat(result.hasNext()).isFalse();
             assertThat(result.getNumberOfElements()).isEqualTo(2);
             assertThat(result.getContent().get(0)).usingRecursiveComparison()
+                .ignoringFields("createdAt")
                 .isEqualTo(findAnimalsResult2);
             assertThat(result.getContent().get(1)).usingRecursiveComparison()
+                .ignoringFields("createdAt")
                 .isEqualTo(findAnimalsResult1);
         }
     }

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
@@ -12,6 +12,7 @@ import com.clova.anifriends.domain.animal.dto.response.FindAnimalsResponse;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalsResponse.FindAnimalResponse;
 import com.clova.anifriends.domain.animal.dto.response.RegisterAnimalResponse;
 import com.clova.anifriends.domain.animal.repository.AnimalCacheRepository;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
 import com.clova.anifriends.domain.animal.support.fixture.AnimalDtoFixture;
 import com.clova.anifriends.domain.animal.support.fixture.AnimalFixture;
 import com.clova.anifriends.domain.animal.vo.AnimalActive;
@@ -141,7 +142,7 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
             List<Animal> animals = AnimalFixture.animals(shelter, animalCount);
             animalRepository.saveAll(animals);
 
-            Slice<Animal> pagination = animalRepository.findAnimalsV2(null,
+            Slice<FindAnimalsResult> pagination = animalRepository.findAnimalsV2(null,
                 null, null, null, null, null,
                 null, null, PageRequest.of(0, size));
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pagination,
@@ -173,7 +174,7 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
             List<Animal> animals = AnimalFixture.animals(shelter, animalCount);
             animalRepository.saveAll(animals);
 
-            Slice<Animal> pagination = animalRepository.findAnimalsV2(null,
+            Slice<FindAnimalsResult> pagination = animalRepository.findAnimalsV2(null,
                 null, null, null, null, null,
                 null, null, PageRequest.of(0, size));
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pagination,
@@ -212,7 +213,7 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
 
             animalService.deleteAnimal(shelter.getShelterId(), animalToDelete.getAnimalId());
 
-            Slice<Animal> pagination = animalRepository.findAnimalsV2(null,
+            Slice<FindAnimalsResult> pagination = animalRepository.findAnimalsV2(null,
                 null, null, null, null, null,
                 null, null, PageRequest.of(0, size));
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pagination,
@@ -250,7 +251,7 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
 
             animalService.deleteAnimal(shelter.getShelterId(), animalToDelete.getAnimalId());
 
-            Slice<Animal> pagination = animalRepository.findAnimalsV2(null,
+            Slice<FindAnimalsResult> pagination = animalRepository.findAnimalsV2(null,
                 null, null, null, null, null,
                 null, null, PageRequest.of(0, size));
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pagination,
@@ -287,7 +288,7 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
             animalService.registerAnimal(shelter.getShelterId(),
                 AnimalDtoFixture.registerAnimal(animalToAdd));
 
-            Slice<Animal> pagination = animalRepository.findAnimalsV2(null,
+            Slice<FindAnimalsResult> pagination = animalRepository.findAnimalsV2(null,
                 null, null, null, null, null,
                 null, null, PageRequest.of(0, size));
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pagination,

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceTest.java
@@ -25,6 +25,8 @@ import com.clova.anifriends.domain.animal.dto.response.FindAnimalsResponse;
 import com.clova.anifriends.domain.animal.exception.AnimalNotFoundException;
 import com.clova.anifriends.domain.animal.repository.AnimalCacheRepository;
 import com.clova.anifriends.domain.animal.repository.AnimalRepository;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
+import com.clova.anifriends.domain.animal.support.fixture.AnimalDtoFixture;
 import com.clova.anifriends.domain.animal.support.fixture.AnimalFixture;
 import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
@@ -100,7 +102,7 @@ class AnimalServiceTest {
             animalService.registerAnimal(1L, registerAnimalRequest);
 
             //then
-            then(animalCacheRepository).should().saveAnimal(any());
+            then(animalCacheRepository).should().saveAnimal(any(Animal.class));
             then(animalRepository).should().save(any());
             then(animalRepository).should().save(any());
             then(animalCacheRepository).should().increaseTotalNumberOfAnimals();
@@ -131,7 +133,8 @@ class AnimalServiceTest {
             Animal animal = animal(shelter);
             FindAnimalDetail expected = FindAnimalDetail.from(animal);
 
-            when(animalRepository.findById(anyLong())).thenReturn(Optional.of(animal));
+            when(animalRepository.findByAnimalIdWithImages(anyLong())).thenReturn(
+                Optional.of(animal));
 
             // when
             FindAnimalDetail result = animalService.findAnimalDetail(
@@ -145,7 +148,7 @@ class AnimalServiceTest {
         @DisplayName("예외(NotFoundAnimalException): 존재하지 않는 보호 동물")
         void exceptionWhenAnimalIsNotExist() {
             // given
-            when(animalRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(animalRepository.findByAnimalIdWithImages(anyLong())).thenReturn(Optional.empty());
 
             // when
             Exception exception = catchException(
@@ -341,9 +344,10 @@ class AnimalServiceTest {
                 mockInformation,
                 mockImageUrls
             );
-
+            FindAnimalsResult findAnimalsResult = AnimalDtoFixture.findAnimalsResult(matchAnimal);
             PageRequest pageRequest = PageRequest.of(0, 10);
-            SliceImpl<Animal> pageResult = new SliceImpl<>(List.of(matchAnimal), pageRequest,
+            SliceImpl<FindAnimalsResult> pageResult = new SliceImpl<>(List.of(findAnimalsResult),
+                pageRequest,
                 false);
 
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pageResult, 1L);
@@ -397,9 +401,10 @@ class AnimalServiceTest {
                 mockInformation,
                 mockImageUrls
             );
-
+            FindAnimalsResult findAnimalsResult = AnimalDtoFixture.findAnimalsResult(matchAnimal);
             PageRequest pageRequest = PageRequest.of(0, 10);
-            SliceImpl<Animal> pageResult = new SliceImpl<>(List.of(matchAnimal), pageRequest,
+            SliceImpl<FindAnimalsResult> pageResult = new SliceImpl<>(List.of(findAnimalsResult),
+                pageRequest,
                 false);
 
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pageResult, 1L);
@@ -455,7 +460,9 @@ class AnimalServiceTest {
             );
 
             PageRequest pageRequest = PageRequest.of(0, 10);
-            SliceImpl<Animal> pageResult = new SliceImpl<>(List.of(matchAnimal), pageRequest,
+            FindAnimalsResult findAnimalsResult = AnimalDtoFixture.findAnimalsResult(matchAnimal);
+            SliceImpl<FindAnimalsResult> pageResult = new SliceImpl<>(List.of(findAnimalsResult),
+                pageRequest,
                 false);
 
             FindAnimalsResponse expected = FindAnimalsResponse.fromV2(pageResult, 1L);

--- a/src/test/java/com/clova/anifriends/domain/animal/support/fixture/AnimalDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/support/fixture/AnimalDtoFixture.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.animal.support.fixture;
 import com.clova.anifriends.domain.animal.Animal;
 import com.clova.anifriends.domain.animal.dto.request.RegisterAnimalRequest;
 import com.clova.anifriends.domain.animal.dto.response.FindAnimalDetail;
+import com.clova.anifriends.domain.animal.repository.response.FindAnimalsResult;
 
 public class AnimalDtoFixture {
 
@@ -23,6 +24,16 @@ public class AnimalDtoFixture {
             animal.getInformation(),
             animal.getImages()
         );
+    }
+
+    public static FindAnimalsResult findAnimalsResult(Animal animal) {
+        return new FindAnimalsResult(
+            animal.getAnimalId(),
+            animal.getName(),
+            animal.getCreatedAt(),
+            animal.getShelter().getName(),
+            animal.getShelter().getAddress(),
+            animal.getImages().get(0));
     }
 
 }


### PR DESCRIPTION
### ⛏ 작업 사항
보호 동물 조회 api 에서 발생한 N+1 문제를 해결했습니다.

### 📝 작업 요약
- `findAnimalDetail` 의 `AnimalImages` 에 `fetch join` 적용
- `findAnimalsByShelter` 의 `AnimalImages` 콜렉션에 `BatchSize` 설정
- `findAnimalsByVolunteerV2` 에 `DTO Projection` 적용

### 💡 관련 이슈
- close #272 
