### PR TITLE
feat: nginx에 파일 용량 제한을 늘린다.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,6 +36,7 @@ http {
             proxy_set_header    Host                $http_host;
             proxy_set_header    X-Real-IP           $remote_addr;
             proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+            client_max_body_size 2500M;
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- nginx에 파일 용량 제한을 2.5GB로 늘린다.

### 📝 작업 요약
- nginx에 파일 용량 제한을 2.5GB로 늘린다.

### 💡 관련 이슈
- close #369 
