### PR TITLE
refactor: FindShelterDetailResponse의 내부 필드명을 API 명세에 맞게 변경한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/shelter/dto/response/FindShelterDetailResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/dto/response/FindShelterDetailResponse.java
@@ -4,13 +4,13 @@ import com.clova.anifriends.domain.shelter.Shelter;
 
 public record FindShelterDetailResponse(
     Long shelterId,
-    String email,
-    String name,
-    String address,
-    String addressDetail,
-    String phoneNumber,
-    String sparePhoneNumber,
-    String imageUrl
+    String shelterEmail,
+    String shelterName,
+    String shelterAddress,
+    String shelterAddressDetail,
+    String shelterPhoneNumber,
+    String shelterSparePhoneNumber,
+    String shelterImageUrl
 
 ) {
 

--- a/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/controller/ShelterControllerTest.java
@@ -168,25 +168,25 @@ class ShelterControllerTest extends BaseControllerTest {
                 responseFields(
                     fieldWithPath("shelterId").type(JsonFieldType.NUMBER)
                         .description("보호소 ID"),
-                    fieldWithPath("email").type(
+                    fieldWithPath("shelterEmail").type(
                             JsonFieldType.STRING)
                         .description("보호소 이메일"),
-                    fieldWithPath("name").type(
+                    fieldWithPath("shelterName").type(
                             JsonFieldType.STRING)
                         .description("보호소 이름"),
-                    fieldWithPath("address").type(
+                    fieldWithPath("shelterAddress").type(
                             JsonFieldType.STRING)
                         .description("보호소 주소"),
-                    fieldWithPath("addressDetail").type(
+                    fieldWithPath("shelterAddressDetail").type(
                             JsonFieldType.STRING)
                         .description("보호소 상세주소"),
-                    fieldWithPath("phoneNumber").type(
+                    fieldWithPath("shelterPhoneNumber").type(
                             JsonFieldType.STRING)
                         .description("보호소 전화번호"),
-                    fieldWithPath("sparePhoneNumber").type(
+                    fieldWithPath("shelterSparePhoneNumber").type(
                             JsonFieldType.STRING)
                         .description("보호소 임시 전화번호"),
-                    fieldWithPath("imageUrl").type(
+                    fieldWithPath("shelterImageUrl").type(
                             JsonFieldType.STRING)
                         .description("보호소 이미지 Url").optional()
                 )


### PR DESCRIPTION
### ⛏ 작업 사항
- FindShelterDetailResponse의 내부 필드명을 API 명세에 맞게 변경

### 📝 작업 요약
- FindShelterDetailResponse의 내부 필드명을 API 명세에 맞게 변경

### 💡 관련 이슈
- close #373 
