### PR TITLE
fix: 모집 마감된 봉사 신청 시 응답 상태 코드를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
@@ -1,7 +1,7 @@
 package com.clova.anifriends.domain.applicant;
 
 import com.clova.anifriends.domain.applicant.exception.ApplicantBadRequestException;
-import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
+import com.clova.anifriends.domain.applicant.exception.ApplicantCanNotApplyException;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.common.BaseTimeEntity;
 import com.clova.anifriends.domain.recruitment.Recruitment;
@@ -76,7 +76,7 @@ public class Applicant extends BaseTimeEntity {
             throw new ApplicantBadRequestException("봉사는 필수 입력 항목입니다.");
         }
         if (recruitment.isClosed() || recruitment.getDeadline().isBefore(LocalDateTime.now())) {
-            throw new ApplicantBadRequestException("모집이 마감된 봉사입니다.");
+            throw new ApplicantCanNotApplyException(ErrorCode.CONCURRENCY, "모집이 마감된 봉사입니다.");
         }
     }
 
@@ -88,7 +88,7 @@ public class Applicant extends BaseTimeEntity {
 
     private void validateApplicantCount(Recruitment recruitment) {
         if (recruitment.isFullApplicants()) {
-            throw new ApplicantConflictException(ErrorCode.CONCURRENCY, "모집 인원이 초과되었습니다.");
+            throw new ApplicantCanNotApplyException(ErrorCode.CONCURRENCY, "모집 인원이 초과되었습니다.");
         }
     }
 

--- a/src/main/java/com/clova/anifriends/domain/applicant/exception/ApplicantCanNotApplyException.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/exception/ApplicantCanNotApplyException.java
@@ -3,9 +3,9 @@ package com.clova.anifriends.domain.applicant.exception;
 import com.clova.anifriends.global.exception.ConflictException;
 import com.clova.anifriends.global.exception.ErrorCode;
 
-public class ApplicantConflictException extends ConflictException {
+public class ApplicantCanNotApplyException extends ConflictException {
 
-    public ApplicantConflictException(ErrorCode errorCode,
+    public ApplicantCanNotApplyException(ErrorCode errorCode,
         String message) {
         super(errorCode, message);
     }

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -4,7 +4,7 @@ import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
-import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
+import com.clova.anifriends.domain.applicant.exception.ApplicantCanNotApplyException;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplicantResult;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplyingVolunteerResult;
@@ -51,7 +51,7 @@ public class ApplicantService {
     private final ShelterRepository shelterRepository;
 
     @Transactional
-    @DataIntegrityHandler(message = "이미 신청한 봉사입니다.", exceptionClass = ApplicantConflictException.class)
+    @DataIntegrityHandler(message = "이미 신청한 봉사입니다.", exceptionClass = ApplicantCanNotApplyException.class)
     public void registerApplicant(Long recruitmentId, Long volunteerId) {
         Recruitment recruitmentPessimistic = getRecruitmentPessimistic(recruitmentId);
         Volunteer volunteer = getVolunteer(volunteerId);
@@ -148,7 +148,8 @@ public class ApplicantService {
             .orElseThrow(() -> new VolunteerNotFoundException("존재하지 않는 봉사자입니다."));
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
             .orElseThrow(() -> new RecruitmentNotFoundException("존재하지 않는 봉사 모집글입니다."));
-        boolean isApplied = applicantRepository.existsByVolunteerAndRecruitment(volunteer, recruitment);
+        boolean isApplied = applicantRepository.existsByVolunteerAndRecruitment(volunteer,
+            recruitment);
         return IsAppliedRecruitmentResponse.from(isApplied);
 
     }

--- a/src/test/java/com/clova/anifriends/domain/applicant/ApplicantTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/ApplicantTest.java
@@ -5,20 +5,15 @@ import static org.assertj.core.api.Assertions.catchException;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.clova.anifriends.domain.applicant.exception.ApplicantBadRequestException;
-import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
-import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
-import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
+import com.clova.anifriends.domain.applicant.exception.ApplicantCanNotApplyException;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
 import com.clova.anifriends.domain.recruitment.vo.RecruitmentInfo;
-import com.clova.anifriends.domain.review.Review;
-import com.clova.anifriends.domain.review.support.ReviewFixture;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,7 +52,7 @@ class ApplicantTest {
         }
 
         @Test
-        @DisplayName("예외(ApplicantBadRequestException): 모집이 마감된 경우")
+        @DisplayName("예외(ApplicantConflictException): 모집이 마감된 경우")
         void throwExceptionWhenRecruitmentIsClosed() {
             //given
             recruitmentInfo = new RecruitmentInfo(
@@ -75,11 +70,11 @@ class ApplicantTest {
             Exception exception = catchException(() -> new Applicant(recruitment, volunteer));
 
             //then
-            assertThat(exception).isInstanceOf(ApplicantBadRequestException.class);
+            assertThat(exception).isInstanceOf(ApplicantCanNotApplyException.class);
         }
 
         @Test
-        @DisplayName("예외(ApplicantBadRequestException): 모집 마감 시간이 지난 경우")
+        @DisplayName("예외(ApplicantConflictException): 모집 마감 시간이 지난 경우")
         void throwExceptionWhenRecruitmentDeadLineIsOver() {
             //given
             recruitmentInfo = new RecruitmentInfo(
@@ -98,7 +93,7 @@ class ApplicantTest {
             Exception exception = catchException(() -> new Applicant(recruitment, volunteer));
 
             //then
-            assertThat(exception).isInstanceOf(ApplicantBadRequestException.class);
+            assertThat(exception).isInstanceOf(ApplicantCanNotApplyException.class);
         }
 
         @Test
@@ -153,7 +148,7 @@ class ApplicantTest {
             Exception exception = catchException(() -> new Applicant(recruitment, volunteer));
 
             //then
-            assertThat(exception).isInstanceOf(ApplicantConflictException.class);
+            assertThat(exception).isInstanceOf(ApplicantCanNotApplyException.class);
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantIntegrationTest.java
@@ -8,7 +8,7 @@ import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
-import com.clova.anifriends.domain.applicant.exception.ApplicantConflictException;
+import com.clova.anifriends.domain.applicant.exception.ApplicantCanNotApplyException;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.recruitment.Recruitment;
@@ -63,7 +63,7 @@ public class ApplicantIntegrationTest extends BaseIntegrationTest {
                     volunteer.getVolunteerId()));
 
             // then
-            assertThat(exception).isInstanceOf(ApplicantConflictException.class);
+            assertThat(exception).isInstanceOf(ApplicantCanNotApplyException.class);
         }
 
         @Test


### PR DESCRIPTION
### ⛏ 작업 사항
- ApplicantConcurrencyException -> ApplicantCanNotApplyException으로 변경
- 모집 마감된 봉사일 때 ApplicantCanNotApplyException을 던지게 변경

### 📝 작업 요약
- 모집 마감된 봉사 신청 시 응답 상태 코드를 수정

### 💡 관련 이슈
- close #376 
