### PR TITLE
fix: 봉사자가 봉사 신청 후 보호소가 승인할 경우 봉사자의 봉사 완료 횟수가 증가하는 버그를 해결한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/FindVolunteerMyPageResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/dto/response/FindVolunteerMyPageResponse.java
@@ -4,6 +4,7 @@ import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerGender;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record FindVolunteerMyPageResponse(
     long volunteerId,
@@ -26,7 +27,9 @@ public record FindVolunteerMyPageResponse(
             volunteer.getPhoneNumber(),
             volunteer.getTemperature(),
             volunteer.getApplicants().stream()
-                .filter(applicant -> applicant.getStatus().equals(ApplicantStatus.ATTENDANCE))
+                .filter(applicant -> applicant.getStatus().equals(ApplicantStatus.ATTENDANCE)
+                    && applicant.getRecruitment().getStartTime().isBefore(
+                    LocalDateTime.now()))
                 .count(),
             volunteer.getVolunteerImageUrl(),
             volunteer.getGender()


### PR DESCRIPTION
### ⛏ 작업 사항
- FindVolunteerMyPageResponse에서 status가 ATTENDENCE이고 현재 시간이 시작 시간 이후여야 봉사 완료 횟수가 증가하도록 수정

### 📝 작업 요약
- 봉사자가 봉사 신청 후 보호소가 승인할 경우 봉사자의 봉사 완료 횟수가 증가하는 버그를 해결한다.

### 💡 관련 이슈
- close #384 
