### PR TITLE
fix: 내(보호소)가 작성한 봉사 모집글 검색 시 키워드 검색이 되지 않는 문제를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -234,16 +234,7 @@ public class RecruitmentRepositoryImpl implements
     }
 
     Predicate getKeywordCondition(String keyword, Boolean content, Boolean title) {
-        BooleanExpression predicate = recruitment.isNotNull();
-        if (keyword == null || keyword.isBlank()) {
-            return predicate;
-        }
-        if (content) {
-            predicate = predicate.or(recruitment.content.content.contains(keyword));
-        }
-        if (title) {
-            predicate = predicate.or(recruitment.title.title.contains(keyword));
-        }
-        return predicate;
+        return nullSafeBuilder(() -> title != null ? recruitmentTitleContains(keyword, title) : null)
+            .or(nullSafeBuilder(() -> content != null ? recruitmentContentContains(keyword, content) : null));
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
내(보호소)가 작성한 봉사 모집글 검색 시 키워드 검색이 되지 않는 문제를 수정한다.

### 📝 작업 요약
`RecruitmentRepositoryImpl`에서 `getKeywordCondition` 메서드 수정

### 💡 관련 이슈
- close #386 
