### PR TITLE
refactor: 테스트 시 애플리케이션 컨텍스트 초기화를 줄여 테스트 속도를 개선한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/notification/service/ShelterNotificationService.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/service/ShelterNotificationService.java
@@ -10,7 +10,6 @@ import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +39,6 @@ public class ShelterNotificationService {
     }
 
     @Transactional
-    @Scheduled(cron = "${schedules.cron.notification.encourage-check-attendance}")
     public void notifyEncourageCheckAttendance() {
         LocalDateTime time1 = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
         LocalDateTime time2 = LocalDateTime.now().withMinute(59).withSecond(59)

--- a/src/main/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationService.java
+++ b/src/main/java/com/clova/anifriends/domain/notification/service/VolunteerNotificationService.java
@@ -13,7 +13,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +43,6 @@ public class VolunteerNotificationService {
     }
 
     @Transactional
-    @Scheduled(cron = "${schedules.cron.notification.a-day-before-volunteer}")
     public void notifyADayBeforeVolunteer() {
         LocalDateTime time1 = LocalDateTime.now().plusDays(1).with(LocalTime.of(0, 1));
         LocalDateTime time2 = LocalDateTime.now().plusDays(1).with(LocalTime.of(23, 59));
@@ -63,7 +61,6 @@ public class VolunteerNotificationService {
     }
 
     @Transactional
-    @Scheduled(cron = "${schedules.cron.notification.three-day-before-volunteer}")
     public void notifyThreeDayBeforeVolunteer() {
         LocalDateTime time1 = LocalDateTime.now().plusDays(3).with(LocalTime.of(0, 1));
         LocalDateTime time2 = LocalDateTime.now().plusDays(3).with(LocalTime.of(23, 59));
@@ -81,7 +78,6 @@ public class VolunteerNotificationService {
     }
 
     @Transactional
-    @Scheduled(cron = "${schedules.cron.notification.encourage-write-review}")
     public void notifyEncourageWriteReview() {
         LocalDateTime time1 = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
         LocalDateTime time2 = LocalDateTime.now().withMinute(59).withSecond(59)

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -24,7 +24,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -283,7 +282,6 @@ public class RecruitmentService {
     }
 
     @Transactional
-    @Scheduled(cron = "${schedules.cron.recruitment.auto-close}")
     public void autoCloseRecruitment() {
         LocalDateTime now = LocalDateTime.now();
         List<Recruitment> recruitments = recruitmentRepository

--- a/src/main/java/com/clova/anifriends/global/scheduler/NotifyScheduler.java
+++ b/src/main/java/com/clova/anifriends/global/scheduler/NotifyScheduler.java
@@ -1,0 +1,35 @@
+package com.clova.anifriends.global.scheduler;
+
+import com.clova.anifriends.domain.notification.service.ShelterNotificationService;
+import com.clova.anifriends.domain.notification.service.VolunteerNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotifyScheduler {
+
+    private final VolunteerNotificationService volunteerNotificationService;
+    private final ShelterNotificationService shelterNotificationService;
+
+    @Scheduled(cron = "${schedules.cron.notification.a-day-before-volunteer}")
+    public void notifyADayBeforeVolunteer() {
+        volunteerNotificationService.notifyADayBeforeVolunteer();
+    }
+
+    @Scheduled(cron = "${schedules.cron.notification.three-day-before-volunteer}")
+    public void notifyThreeDayBeforeVolunteer() {
+        volunteerNotificationService.notifyThreeDayBeforeVolunteer();
+    }
+
+    @Scheduled(cron = "${schedules.cron.notification.encourage-write-review}")
+    public void notifyEncourageWriteReview() {
+        volunteerNotificationService.notifyEncourageWriteReview();
+    }
+
+    @Scheduled(cron = "${schedules.cron.notification.encourage-check-attendance}")
+    public void notifyEncourageCheckAttendance() {
+        shelterNotificationService.notifyEncourageCheckAttendance();
+    }
+}

--- a/src/main/java/com/clova/anifriends/global/scheduler/ServiceScheduler.java
+++ b/src/main/java/com/clova/anifriends/global/scheduler/ServiceScheduler.java
@@ -1,0 +1,18 @@
+package com.clova.anifriends.global.scheduler;
+
+import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ServiceScheduler {
+
+    private final RecruitmentService recruitmentService;
+
+    @Scheduled(cron = "${schedules.cron.recruitment.auto-close}")
+    public void autoCloseRecruitment() {
+        recruitmentService.autoCloseRecruitment();
+    }
+}

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -10,10 +10,12 @@ import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
 import com.clova.anifriends.global.config.RedisConfig;
 import com.clova.anifriends.global.config.SecurityConfig;
+import com.clova.anifriends.global.image.S3Service;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -51,6 +53,9 @@ public abstract class BaseIntegrationTest extends TestContainerStarter {
 
     @Autowired
     protected AnimalRepository animalRepository;
+
+    @MockBean
+    protected S3Service s3Service;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/clova/anifriends/base/BaseSchedulerTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseSchedulerTest.java
@@ -1,0 +1,20 @@
+package com.clova.anifriends.base;
+
+import com.clova.anifriends.domain.notification.service.ShelterNotificationService;
+import com.clova.anifriends.domain.notification.service.VolunteerNotificationService;
+import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@SpringBootTest
+public abstract class BaseSchedulerTest {
+
+    @SpyBean
+    protected RecruitmentService recruitmentService;
+
+    @SpyBean
+    protected VolunteerNotificationService volunteerNotificationService;
+
+    @SpyBean
+    protected ShelterNotificationService shelterNotificationService;
+}

--- a/src/test/java/com/clova/anifriends/base/BaseSchedulerTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseSchedulerTest.java
@@ -1,20 +1,43 @@
 package com.clova.anifriends.base;
 
+import com.clova.anifriends.base.BaseSchedulerTest.SchedulerConfig;
 import com.clova.anifriends.domain.notification.service.ShelterNotificationService;
 import com.clova.anifriends.domain.notification.service.VolunteerNotificationService;
 import com.clova.anifriends.domain.recruitment.service.RecruitmentService;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@SpringBootTest
+@SpringJUnitConfig(SchedulerConfig.class)
 public abstract class BaseSchedulerTest {
 
-    @SpyBean
+    @TestConfiguration
+    @EnableScheduling
+    @ComponentScan("com.clova.anifriends.global.scheduler")
+    static class SchedulerConfig {
+
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        Properties properties = System.getProperties();
+        properties.setProperty("schedules.cron.notification.a-day-before-volunteer", "* * * * * ?");
+        properties.setProperty("schedules.cron.notification.three-day-before-volunteer", "* * * * * ?");
+        properties.setProperty("schedules.cron.notification.encourage-write-review", "* * * * * ?");
+        properties.setProperty("schedules.cron.notification.encourage-check-attendance", "* * * * * ?");
+        properties.setProperty("schedules.cron.recruitment.auto-close", "* * * * * ?");
+    }
+
+    @MockBean
     protected RecruitmentService recruitmentService;
 
-    @SpyBean
+    @MockBean
     protected VolunteerNotificationService volunteerNotificationService;
 
-    @SpyBean
+    @MockBean
     protected ShelterNotificationService shelterNotificationService;
 }

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
@@ -20,14 +20,12 @@ import com.clova.anifriends.domain.animal.vo.AnimalGender;
 import com.clova.anifriends.domain.animal.vo.AnimalType;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
-import com.clova.anifriends.global.image.S3Service;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,9 +37,6 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     AnimalCacheRepository animalCacheRepository;
-
-    @MockBean
-    S3Service s3Service;
 
     @Nested
     @DisplayName("registerAnimal 메서드 실행 시")

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
@@ -15,14 +15,12 @@ import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
-import com.clova.anifriends.global.image.S3Service;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class RecruitmentIntegrationTest extends BaseIntegrationTest {
 
@@ -34,9 +32,6 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     RecruitmentRepository recruitmentRepository;
-
-    @MockBean
-    S3Service s3Service;
 
     @Nested
     @DisplayName("updateRecruitment 메서드 호출 시")

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -19,22 +19,17 @@ import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
-import com.clova.anifriends.global.image.S3Service;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class ReviewIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     ReviewService reviewService;
-
-    @MockBean
-    S3Service s3Service;
 
     @Nested
     @DisplayName("deleteReview 메서드 호출 시")

--- a/src/test/java/com/clova/anifriends/global/scheduler/NotifySchedulerTest.java
+++ b/src/test/java/com/clova/anifriends/global/scheduler/NotifySchedulerTest.java
@@ -1,22 +1,16 @@
-package com.clova.anifriends.domain.notification.service;
+package com.clova.anifriends.global.scheduler;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
-import com.clova.anifriends.base.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseSchedulerTest;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 
-class NotificationScheduledTest extends BaseIntegrationTest {
-
-    @SpyBean
-    private VolunteerNotificationService volunteerNotificationService;
-
-    @SpyBean
-    private ShelterNotificationService shelterNotificationService;
+class NotifySchedulerTest extends BaseSchedulerTest {
 
     @Test
     @DisplayName("notifyADayBeforeVolunteer 메서드 실행 시")

--- a/src/test/java/com/clova/anifriends/global/scheduler/ServiceSchedulerTest.java
+++ b/src/test/java/com/clova/anifriends/global/scheduler/ServiceSchedulerTest.java
@@ -1,19 +1,16 @@
-package com.clova.anifriends.domain.recruitment.service;
+package com.clova.anifriends.global.scheduler;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
-import com.clova.anifriends.base.BaseIntegrationTest;
+import com.clova.anifriends.base.BaseSchedulerTest;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
-class RecruitmentScheduledTest extends BaseIntegrationTest {
-
-    @SpyBean
-    private RecruitmentService recruitmentService;
+class ServiceSchedulerTest extends BaseSchedulerTest {
 
     @Test
     @DisplayName("autoCloseRecruitment 메서드 실행 시")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -38,10 +38,10 @@ cloud:
 schedules:
   cron:
     notification:
-      a-day-before-volunteer: 0/2 * * * * ?
-      three-day-before-volunteer: 0/2 * * * * ?
-      encourage-write-review: 0/2 * * * * ?
-      encourage-check-attendance: 0/2 * * * * ?
+      a-day-before-volunteer: "* * * * * ?"
+      three-day-before-volunteer: "* * * * * ?"
+      encourage-write-review: "* * * * * ?"
+      encourage-check-attendance: "* * * * * ?"
     recruitment:
-      auto-close: 0/2 * * * * ?
-      
+      auto-close: "* * * * * ?"
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,8 +17,8 @@ spring:
   jpa:
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+#        format_sql: true
+#        show_sql: true
   data:
     redis:
       host: localhost


### PR DESCRIPTION
### ⛏ 작업 사항
- 테스트를 위한 스케줄러 표현식을 매초 실행으로 변경하였습니다.
- 스케줄러와 서비스 로직을 분리하였습니다. 이에 맞춰 새로운 테스트 클래스를 생성하였습니다.
- 스케줄러 행위 테스트를 위한 `BaseSchedulerTest`를 생성하였습니다. 새롭게 생성한 스케줄러 클래스 테스트는 이를 사용합니다. 스케줄러 애플리케이션 컨텍스트 초기화 횟수가 기존 2개 -> 1개로 감소하였습니다.
- S3Service mock을 `BaseIntegrationTest`로 이동시켰습니다.
- 컨텍스트 초기화 횟수를 8회 -> 6회로 감소시켰습니다. 테스트 시간이 약 17초에서 12초로 감소하였습니다.

### 📝 작업 요약
- 스케줄링, 서비스 로직 분리
- `BaseSchedulerTest` 추가
- 테스트 시 `S3Service` MockBean 선언 위치 변경

### 💡 관련 이슈
- close #387 
