### PR TITLE
refactor: 봉사 모집글 목록 조회 쿼리를 개선한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/controller/ApplicantController.java
@@ -10,7 +10,7 @@ import com.clova.anifriends.domain.applicant.service.dto.UpdateApplicantAttendan
 import com.clova.anifriends.domain.auth.LoginUser;
 import com.clova.anifriends.domain.auth.authorization.ShelterOnly;
 import com.clova.anifriends.domain.auth.authorization.VolunteerOnly;
-import com.clova.anifriends.domain.recruitment.service.IsAppliedRecruitmentResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.IsAppliedRecruitmentResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -18,7 +18,7 @@ import com.clova.anifriends.domain.notification.vo.NotificationType;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
-import com.clova.anifriends.domain.recruitment.service.IsAppliedRecruitmentResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.IsAppliedRecruitmentResponse;
 import com.clova.anifriends.domain.review.exception.ApplicantNotFoundException;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/IsAppliedRecruitmentResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/IsAppliedRecruitmentResponse.java
@@ -1,4 +1,4 @@
-package com.clova.anifriends.domain.recruitment.service;
+package com.clova.anifriends.domain.recruitment.dto.response;
 
 public record IsAppliedRecruitmentResponse(boolean isAppliedRecruitment) {
 

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.recruitment.repository;
 
 import static com.clova.anifriends.domain.recruitment.QRecruitment.recruitment;
+import static com.clova.anifriends.domain.shelter.QShelter.shelter;
 
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.querydsl.core.BooleanBuilder;
@@ -33,8 +34,8 @@ public class RecruitmentRepositoryImpl implements
         boolean shelterNameContains, Pageable pageable) {
         List<Recruitment> content = query.select(recruitment)
             .from(recruitment)
-            .join(recruitment.shelter)
-            .leftJoin(recruitment.applicants)
+            .join(recruitment.shelter).fetchJoin()
+            .leftJoin(shelter.image).fetchJoin()
             .where(
                 keywordSearch(keyword, titleContains, contentContains, shelterNameContains),
                 recruitmentIsClosed(isClosed),
@@ -65,8 +66,8 @@ public class RecruitmentRepositoryImpl implements
         Pageable pageable) {
         List<Recruitment> content = query.select(recruitment)
             .from(recruitment)
-            .join(recruitment.shelter)
-            .leftJoin(recruitment.applicants)
+            .join(recruitment.shelter).fetchJoin()
+            .leftJoin(shelter.image).fetchJoin()
             .where(
                 keywordSearch(keyword, titleContains, contentContains, shelterNameContains),
                 recruitmentIsClosed(isClosed),

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -38,7 +38,7 @@ import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicants
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.common.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
-import com.clova.anifriends.domain.recruitment.service.IsAppliedRecruitmentResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.IsAppliedRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;

--- a/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/service/ApplicantServiceTest.java
@@ -35,7 +35,7 @@ import com.clova.anifriends.domain.notification.repository.VolunteerNotification
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
-import com.clova.anifriends.domain.recruitment.service.IsAppliedRecruitmentResponse;
+import com.clova.anifriends.domain.recruitment.dto.response.IsAppliedRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
 import com.clova.anifriends.domain.recruitment.vo.RecruitmentApplicantCount;
 import com.clova.anifriends.domain.recruitment.vo.RecruitmentInfo;

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
@@ -8,7 +8,6 @@ import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.RecruitmentImage;
-import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
 import com.clova.anifriends.domain.shelter.Shelter;
@@ -17,7 +16,6 @@ import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import com.clova.anifriends.domain.volunteer.Volunteer;
 import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
 import com.clova.anifriends.global.image.S3Service;
-import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +23,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageRequest;
 
 public class RecruitmentIntegrationTest extends BaseIntegrationTest {
 
@@ -130,45 +127,6 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
             Recruitment findRecruitment = entityManager.find(Recruitment.class,
                 recruitment.getRecruitmentId());
             assertThat(findRecruitment).isNull();
-        }
-    }
-
-    @Nested
-    @DisplayName("Recruitment N+1 검증 시")
-    class NPlusOneTest {
-
-        String keyword;
-        LocalDate startDate;
-        LocalDate endDate;
-        Boolean isClosed;
-        boolean titleContains;
-        boolean contentContains;
-        boolean shelterNameContains;
-
-        @BeforeEach
-        void setUp() {
-            titleContains = true;
-            contentContains = true;
-            shelterNameContains = true;
-        }
-
-        @Test
-        @DisplayName("findRecruitments 메서드 호출 시")
-        void findRecruitments() {
-            //given
-            Shelter shelter = ShelterFixture.shelter();
-            Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
-            shelterRepository.save(shelter);
-            recruitmentRepository.save(recruitment);
-            PageRequest pageRequest = PageRequest.of(0, 10);
-
-            //when
-            FindRecruitmentsResponse recruitments = recruitmentService.findRecruitments(keyword,
-                startDate, endDate, isClosed, titleContains, contentContains, shelterNameContains,
-                pageRequest);
-
-            //then
-            assertThat(recruitments.recruitments()).hasSize(1);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사 모집글 목록 조회 v1, v2 쿼리에 페치 조인을 적용하여 n+1 문제를 개선하였습니다.

### 📝 작업 요약
- 봉사 모집글 목록 조회 페치 조인 적용

### 💡 관련 이슈
- close #366 
