### PR TITLE
fix: 리뷰 업데이트 시 이미지 컬렉션에 대한 참조를 변경하지 않도록 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/Review.java
+++ b/src/main/java/com/clova/anifriends/domain/review/Review.java
@@ -109,12 +109,9 @@ public class Review extends BaseTimeEntity {
     private void addNewImageUrls(List<String> updateImageUrls) {
         List<ReviewImage> existsReviewImages = filterRemainImages(updateImageUrls);
         List<ReviewImage> newReviewImages = filterNewImages(updateImageUrls);
-
-        List<ReviewImage> newImages = new ArrayList<>();
-        newImages.addAll(existsReviewImages);
-        newImages.addAll(newReviewImages);
-
-        this.images = newImages;
+        this.images.clear();
+        this.images.addAll(existsReviewImages);
+        this.images.addAll(newReviewImages);
     }
 
     private List<ReviewImage> filterRemainImages(List<String> updateImageUrls) {

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -150,7 +150,12 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
                 updateContent, updateImageUrls);
 
             //then
-            Review updatedReview = entityManager.find(Review.class, review.getReviewId());
+            Review updatedReview = entityManager.createQuery(
+                    "select r from Review r"
+                        + " left join fetch r.images"
+                        + " where r.reviewId = :reviewId", Review.class)
+                .setParameter("reviewId", review.getReviewId())
+                .getSingleResult();
             assertThat(updatedReview.getContent()).isEqualTo(updateContent);
             assertThat(updatedReview.getImages()).containsExactlyElementsOf(updateImageUrls);
         }

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -113,4 +113,46 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
 
         }
     }
+
+    @Nested
+    @DisplayName("updateReview 메서드 호출 시")
+    class UpdateReviewTest {
+
+        Shelter shelter;
+        Recruitment recruitment;
+        Volunteer volunteer;
+
+        @BeforeEach
+        void setUp() {
+            shelter = ShelterFixture.shelter();
+            recruitment = RecruitmentFixture.recruitment(shelter);
+            volunteer = VolunteerFixture.volunteer();
+            shelterRepository.save(shelter);
+            recruitmentRepository.save(recruitment);
+            volunteerRepository.save(volunteer);
+        }
+
+        @Test
+        @DisplayName("성공: 리뷰 업데이트 됨")
+        void updateReviewImages() {
+            //given
+            Applicant applicant = ApplicantFixture.applicant(recruitment, volunteer,
+                ApplicantStatus.ATTENDANCE);
+            applicantRepository.save(applicant);
+            Review review = ReviewFixture.review(applicant);
+            reviewRepository.save(review);
+
+            String updateContent = "a".repeat(50);
+            List<String> updateImageUrls = List.of("updateImage1", "updateImage2");
+
+            //when
+            reviewService.updateReview(volunteer.getVolunteerId(), review.getReviewId(),
+                updateContent, updateImageUrls);
+
+            //then
+            Review updatedReview = entityManager.find(Review.class, review.getReviewId());
+            assertThat(updatedReview.getContent()).isEqualTo(updateContent);
+            assertThat(updatedReview.getImages()).containsExactlyElementsOf(updateImageUrls);
+        }
+    }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 리뷰 이미지 업데이트 시 이미지 컬렉션에 대한 참조를 변경하지 않도록 수정하였습니다.
- 리뷰 업데이트에 대한 통합 테스트를 추가하였습니다.

### 📝 작업 요약
- 리뷰 업데이트 로직 수정

### 💡 관련 이슈
- close #392 
