### PR TITLE
fix: 리뷰 등록 api 요청 변수 이름을 수정한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/clova/anifriends/domain/review/controller/ReviewController.java
@@ -49,7 +49,7 @@ public class ReviewController {
     ) {
         RegisterReviewResponse registerReviewResponse = reviewService.registerReview(
             volunteerId,
-            request.applicationId(),
+            request.applicantId(),
             request.content(),
             request.imageUrls());
         URI location = URI.create("/api/volunteers/reviews/" + registerReviewResponse.reviewId());

--- a/src/main/java/com/clova/anifriends/domain/review/dto/request/RegisterReviewRequest.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/request/RegisterReviewRequest.java
@@ -3,7 +3,7 @@ package com.clova.anifriends.domain.review.dto.request;
 import java.util.List;
 
 public record RegisterReviewRequest(
-    Long applicationId,
+    Long applicantId,
     String content,
     List<String> imageUrls
 ) {

--- a/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
@@ -200,7 +200,7 @@ class ReviewControllerTest extends BaseControllerTest {
                     headerWithName(AUTHORIZATION).description("봉사자 액세스 토큰")
                 ),
                 requestFields(
-                    fieldWithPath("applicationId").type(NUMBER).description("봉사 신청 ID"),
+                    fieldWithPath("applicantId").type(NUMBER).description("봉사 신청 ID"),
                     fieldWithPath("content").type(STRING).description("리뷰 내용")
                         .description(DocumentationFormatGenerator.getConstraint("10 ~ 300자")),
                     fieldWithPath("imageUrls[]").type(ARRAY).description("리뷰 이미지 url 리스트")


### PR DESCRIPTION
### ⛏ 작업 사항
- 리뷰 등록 API 요청 dto의 변수명 중 API 명세와 다른 부분이 있어 이를 수정하였습니다.

### 📝 작업 요약
- `RegisterReviewRequest`의 인스턴스 변수명 수정

### 💡 관련 이슈
- close #396 
