### PR TITLE
fix: 봉사 모집 조회 시 이미지를 left join 하도록 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -31,7 +31,7 @@ public interface RecruitmentRepository
         @Param("shelterId") long shelterId, @Param("recruitmentId") long recruitmentId);
 
     @Query("select r from Recruitment r"
-        + " join fetch r.images"
+        + " left join fetch r.images"
         + " where r.recruitmentId = :recruitmentId"
         + " and r.shelter.shelterId = :shelterId")
     Optional<Recruitment> findByShelterIdAndRecruitmentIdWithImages(

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -496,4 +496,28 @@ class RecruitmentRepositoryTest extends BaseRepositoryTest {
             assertThat(recruitments.get(0)).isEqualTo(recruitment1);
         }
     }
+
+    @Nested
+    @DisplayName("findByShelterIdAndRecruitmentId 메서드 실행 시")
+    class FindByShelterIdAndRecruitmentIdTest {
+
+        @Test
+        @DisplayName("성공: 모집 글의 이미지가 없는 경우")
+        void findByShelterIdAndRecruitmentId() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            Recruitment recruitment = RecruitmentFixture.recruitmentWithImages(shelter, List.of());
+
+            shelterRepository.save(shelter);
+            recruitmentRepository.save(recruitment);
+
+            // when
+            Optional<Recruitment> result = recruitmentRepository.findByShelterIdAndRecruitmentId(
+                shelter.getShelterId(), recruitment.getRecruitmentId());
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(recruitment);
+        }
+    }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
봉사 모집 조회 시 이미지를 left join 하도록 수정한다.

### 📝 작업 요약
봉사 모집 조회 시 이미지를 left join 하도록 수정한다.

### 💡 관련 이슈
- close #399 
