### PR TITLE
fix: 내(보호소)가 받은 리뷰 목록 조회시 데이터 조회가 되지 않는 문제를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
@@ -1,8 +1,10 @@
 package com.clova.anifriends.domain.review.dto.response;
 
 import com.clova.anifriends.domain.common.PageInfo;
+import com.clova.anifriends.domain.review.Review;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record FindShelterReviewsByShelterResponse(List<FindShelterReviewResponse> reviews,
                                                   PageInfo pageInfo) {
@@ -13,11 +15,31 @@ public record FindShelterReviewsByShelterResponse(List<FindShelterReviewResponse
         String content,
         List<String> reviewImageUrls,
         Long volunteerId,
-
         String volunteerName,
         int temperature,
         String volunteerImageUrl,
         long VolunteerReviewCount) {
+
+        public static FindShelterReviewResponse from(Review review) {
+            return new FindShelterReviewResponse(
+                review.getReviewId(),
+                review.getCreatedAt(),
+                review.getContent(),
+                review.getImages(),
+                review.getVolunteer().getVolunteerId(),
+                review.getVolunteer().getName(),
+                review.getVolunteer().getTemperature(),
+                review.getVolunteer().getVolunteerImageUrl(),
+                review.getVolunteer().getReviewCount()
+            );
+        }
     }
 
+    public static FindShelterReviewsByShelterResponse from(Page<Review> reviewPage) {
+        List<FindShelterReviewResponse> content = reviewPage
+            .map(FindShelterReviewResponse::from)
+            .toList();
+        PageInfo pageInfo = PageInfo.of(reviewPage.getTotalElements(), reviewPage.hasNext());
+        return new FindShelterReviewsByShelterResponse(content, pageInfo);
+    }
 }

--- a/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
@@ -33,9 +33,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         Pageable pageable);
 
     @Query("select r from Review r"
-        + " left join r.images"
-        + " join r.applicant.volunteer v"
-        + " left join v.image"
+        + " left join fetch r.images" 
+        + " join fetch r.applicant a"
+        + " join fetch a.volunteer v"
+        + " left join fetch v.image"
         + " where r.applicant.recruitment.shelter = :shelter")
     Page<Review> findShelterReviewsByShelter(@Param("shelter") Shelter shelter,
         Pageable pageable);

--- a/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,7 @@
 package com.clova.anifriends.domain.review.repository;
 
 import com.clova.anifriends.domain.review.Review;
-import com.clova.anifriends.domain.review.repository.response.FindShelterReviewResult;
+import com.clova.anifriends.domain.shelter.Shelter;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,22 +32,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         @Param("volunteerId") Long volunteerId,
         Pageable pageable);
 
-
-    @Query("select "
-        + "r.reviewId as reviewId, "
-        + "r.createdAt as createdAt, "
-        + "r.content.content as content, "
-        + "r.images as reviewImages, "
-        + "v.volunteerId as volunteerId, "
-        + "v.name.name as volunteerName, "
-        + "v.temperature.temperature as temperature, "
-        + "(select count(r2.reviewId) from Review r2 "
-        + "where r2.applicant.volunteer.volunteerId = v.volunteerId) as volunteerReviewCount, "
-        + "i.imageUrl as volunteerImageUrl "
-        + "from Review r "
-        + "join r.applicant.volunteer v "
-        + "left join v.image i "
-        + "where r.applicant.recruitment.shelter.shelterId = :shelterId")
-    Page<FindShelterReviewResult> findShelterReviewsByShelter(@Param("shelterId") Long shelterId,
+    @Query("select r from Review r"
+        + " left join r.images"
+        + " join r.applicant.volunteer v"
+        + " left join v.image"
+        + " where r.applicant.recruitment.shelter = :shelter")
+    Page<Review> findShelterReviewsByShelter(@Param("shelter") Shelter shelter,
         Pageable pageable);
 }

--- a/src/main/java/com/clova/anifriends/domain/review/repository/response/FindShelterReviewResultV2.java
+++ b/src/main/java/com/clova/anifriends/domain/review/repository/response/FindShelterReviewResultV2.java
@@ -1,0 +1,18 @@
+package com.clova.anifriends.domain.review.repository.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface FindShelterReviewResultV2 {
+
+    Long getReviewId();
+    LocalDateTime getCreatedAt();
+    String getContent();
+    List<String> getReviewImages();
+    Long getVolunteerId();
+    String getVolunteerName();
+    String getVolunteerEmail();
+    int getTemperature();
+    String getVolunteerImageUrl();
+    Long getVolunteerReviewCount();
+}

--- a/src/main/java/com/clova/anifriends/domain/volunteer/VolunteerImage.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/VolunteerImage.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "voulunteer_image")
+@Table(name = "volunteer_image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VolunteerImage extends BaseTimeEntity {
 

--- a/src/test/java/com/clova/anifriends/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/repository/ReviewRepositoryTest.java
@@ -14,19 +14,13 @@ import com.clova.anifriends.base.BaseRepositoryTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.review.Review;
-import com.clova.anifriends.domain.review.ReviewImage;
-import com.clova.anifriends.domain.review.repository.response.FindShelterReviewResult;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.volunteer.Volunteer;
-import com.clova.anifriends.domain.volunteer.VolunteerImage;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class ReviewRepositoryTest extends BaseRepositoryTest {
 
@@ -107,37 +101,5 @@ class ReviewRepositoryTest extends BaseRepositoryTest {
         // then
         assertThat(exception).isInstanceOf(DataIntegrityViolationException.class);
 
-    }
-
-    @Test
-    @DisplayName("성공")
-    void findShelterReviewsByShelter() {
-        // given
-        Shelter shelter = shelter();
-        Volunteer volunteer = volunteer();
-        Recruitment recruitment = recruitment(shelter);
-        Applicant applicant = applicant(recruitment, volunteer, ATTENDANCE);
-        Review review = review(applicant);
-        ReviewImage reviewImage = new ReviewImage(review, "https://anifriends.com/1.jpg");
-        ReflectionTestUtils.setField(review, "images", List.of(reviewImage));
-        VolunteerImage volunteerImage = new VolunteerImage(volunteer, "https://anifriends.com/1.jpg");
-        ReflectionTestUtils.setField(volunteer, "image", volunteerImage);
-
-        shelterRepository.save(shelter);
-        volunteerRepository.save(volunteer);
-        recruitmentRepository.save(recruitment);
-        applicantRepository.save(applicant);
-        reviewRepository.save(review);
-
-        PageRequest pageRequest = PageRequest.of(0, 10);
-
-        // when
-        Page<FindShelterReviewResult> result = reviewRepository.findShelterReviewsByShelter(shelter.getShelterId(), pageRequest);
-
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getReviewId()).isEqualTo(review.getReviewId());
-        assertThat(result.getTotalElements()).isEqualTo(1L);
-        assertThat(result.getContent().get(0).getTemperature()).isEqualTo(volunteer.getTemperature());
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 프로젝션으로 조회하던 것을 엔티티를 조회해오도록 수정하였습니다.
- 현재 reviewCount 조회 시 n+1 문제가 발생하여 최적화가 필요합니다.

### 📝 작업 요약
- 내(보호소)가 받은 리뷰 목록 조회 프로젝션에서 엔티티 조회로 변경

### 💡 관련 이슈
- close #405 
