### PR TITLE
fix: FindShelterReviewResponse에서 VolunteerReviewCount 이름을 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
@@ -18,7 +18,7 @@ public record FindShelterReviewsByShelterResponse(List<FindShelterReviewResponse
         String volunteerName,
         int temperature,
         String volunteerImageUrl,
-        long VolunteerReviewCount) {
+        long volunteerReviewCount) {
 
         public static FindShelterReviewResponse from(Review review) {
             return new FindShelterReviewResponse(

--- a/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
@@ -126,7 +126,8 @@ class ReviewControllerTest extends BaseControllerTest {
             review.getVolunteer().getTemperature(),
             review.getVolunteer().getVolunteerImageUrl(),
             review.getVolunteer().getReviewCount(), List.of(new ReviewImage(review, "urls")));
-        PageImpl<FindShelterReviewResult> reviewPage = new PageImpl<>(List.of(findShelterReviewResult));
+        PageImpl<FindShelterReviewResult> reviewPage = new PageImpl<>(
+            List.of(findShelterReviewResult));
         FindShelterReviewsByShelterResponse response = ReviewMapper.resultToResponse(reviewPage);
 
         given(reviewService.findShelterReviewsByShelter(anyLong(), any())).willReturn(response);
@@ -160,7 +161,7 @@ class ReviewControllerTest extends BaseControllerTest {
                     fieldWithPath("reviews[].temperature").type(NUMBER).description("봉사자 온도"),
                     fieldWithPath("reviews[].volunteerImageUrl").type(STRING)
                         .description("봉사자 프로필 이미지 url").optional(),
-                    fieldWithPath("reviews[].VolunteerReviewCount").type(NUMBER)
+                    fieldWithPath("reviews[].volunteerReviewCount").type(NUMBER)
                         .description("봉사자 리뷰 수"),
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
                     fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewServiceTest.java
@@ -215,7 +215,7 @@ class ReviewServiceTest {
             assertThat(findReview.content()).isEqualTo(review.getContent());
             assertThat(findReview.reviewImageUrls()).isEqualTo(review.getImages());
             assertThat(findReview.temperature()).isEqualTo(volunteer.getTemperature());
-            assertThat(findReview.VolunteerReviewCount()).isEqualTo(volunteer.getReviewCount());
+            assertThat(findReview.volunteerReviewCount()).isEqualTo(volunteer.getReviewCount());
             assertThat(findReview.volunteerName()).isEqualTo(volunteer.getName());
             assertThat(findReview.volunteerImageUrl()).isEqualTo(volunteer.getVolunteerImageUrl());
         }


### PR DESCRIPTION
### ⛏ 작업 사항
- FindShelterReviewResponse의 VolunteerReviewCount를 volunteerReviewCount로 변경한다.

### 📝 작업 요약
- FindShelterReviewResponse에서 VolunteerReviewCount 이름을 수정한다.

### 💡 관련 이슈
- close #411 
