### PR TITLE
fix: FindShelterReviewResponse를 API 명세에 맞게 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsByShelterResponse.java
@@ -11,12 +11,12 @@ public record FindShelterReviewsByShelterResponse(List<FindShelterReviewResponse
 
     public record FindShelterReviewResponse(
         Long reviewId,
-        LocalDateTime createdAt,
-        String content,
+        LocalDateTime reviewCreatedAt,
+        String reviewContent,
         List<String> reviewImageUrls,
         Long volunteerId,
         String volunteerName,
-        int temperature,
+        int volunteerTemperature,
         String volunteerImageUrl,
         long volunteerReviewCount) {
 

--- a/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/controller/ReviewControllerTest.java
@@ -152,13 +152,14 @@ class ReviewControllerTest extends BaseControllerTest {
                 responseFields(
                     fieldWithPath("reviews").type(ARRAY).description("리뷰 리스트"),
                     fieldWithPath("reviews[].reviewId").type(NUMBER).description("리뷰 ID"),
-                    fieldWithPath("reviews[].createdAt").type(STRING).description("리뷰 생성일"),
-                    fieldWithPath("reviews[].content").type(STRING).description("리뷰 내용"),
+                    fieldWithPath("reviews[].reviewCreatedAt").type(STRING).description("리뷰 생성일"),
+                    fieldWithPath("reviews[].reviewContent").type(STRING).description("리뷰 내용"),
                     fieldWithPath("reviews[].reviewImageUrls").type(ARRAY)
                         .description("리뷰 이미지 url 리스트").optional(),
                     fieldWithPath("reviews[].volunteerId").type(NUMBER).description("봉사자 ID"),
                     fieldWithPath("reviews[].volunteerName").type(STRING).description("봉사자 이름"),
-                    fieldWithPath("reviews[].temperature").type(NUMBER).description("봉사자 온도"),
+                    fieldWithPath("reviews[].volunteerTemperature").type(NUMBER)
+                        .description("봉사자 온도"),
                     fieldWithPath("reviews[].volunteerImageUrl").type(STRING)
                         .description("봉사자 프로필 이미지 url").optional(),
                     fieldWithPath("reviews[].volunteerReviewCount").type(NUMBER)

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewServiceTest.java
@@ -212,9 +212,9 @@ class ReviewServiceTest {
 
             //then
             FindShelterReviewResponse findReview = response.reviews().get(0);
-            assertThat(findReview.content()).isEqualTo(review.getContent());
+            assertThat(findReview.reviewContent()).isEqualTo(review.getContent());
             assertThat(findReview.reviewImageUrls()).isEqualTo(review.getImages());
-            assertThat(findReview.temperature()).isEqualTo(volunteer.getTemperature());
+            assertThat(findReview.volunteerTemperature()).isEqualTo(volunteer.getTemperature());
             assertThat(findReview.volunteerReviewCount()).isEqualTo(volunteer.getReviewCount());
             assertThat(findReview.volunteerName()).isEqualTo(volunteer.getName());
             assertThat(findReview.volunteerImageUrl()).isEqualTo(volunteer.getVolunteerImageUrl());


### PR DESCRIPTION
### ⛏ 작업 사항
- content, createdAt, temperature를 API 명세에 맞게 수정

### 📝 작업 요약
- FindShelterReviewResponse를 API 명세에 맞게 수정한다.

### 💡 관련 이슈
- close #413 
