### PR TITLE
refactor: 봉사자가 작성한 후기 개수를 반정규화한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/Applicant.java
@@ -98,16 +98,17 @@ public class Applicant extends BaseTimeEntity {
 
     public void registerReview(Review review) {
         this.review = review;
+        this.volunteer.increaseReviewCount();
+    }
+
+    public void increaseTemperature(int temperature) {
+        this.volunteer.increaseTemperature(temperature);
     }
 
     public void updateApplicantStatus(Boolean isApproved) {
         if (Objects.nonNull(isApproved)) {
             this.status = isApproved ? ApplicantStatus.ATTENDANCE : ApplicantStatus.REFUSED;
         }
-    }
-
-    public void increaseTemperature(int temperature) {
-        this.volunteer.increaseTemperature(temperature);
     }
 
     public ApplicantStatus getStatus() {

--- a/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
@@ -35,6 +35,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r from Review r"
         + " join fetch r.applicant a"
         + " join fetch a.volunteer v"
+        + " left join fetch r.images"
         + " left join fetch v.image"
         + " where r.applicant.recruitment.shelter = :shelter")
     Page<Review> findShelterReviewsByShelter(@Param("shelter") Shelter shelter,

--- a/src/main/java/com/clova/anifriends/domain/review/service/ReviewService.java
+++ b/src/main/java/com/clova/anifriends/domain/review/service/ReviewService.java
@@ -20,6 +20,8 @@ import com.clova.anifriends.domain.review.repository.ReviewRepository;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
+import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.exception.VolunteerNotFoundException;
 import com.clova.anifriends.domain.volunteer.repository.VolunteerRepository;
 import com.clova.anifriends.global.aspect.DataIntegrityHandler;
 import java.util.List;
@@ -110,10 +112,17 @@ public class ReviewService {
 
     @Transactional
     public void deleteReview(Long volunteerId, Long reviewId) {
+        Volunteer volunteer = getVolunteer(volunteerId);
         Review review = getReview(volunteerId, reviewId);
+        volunteer.decreaseReviewCount();
         List<String> imagesToDelete = review.getImages();
         applicationEventPublisher.publishEvent(new ImageDeletionEvent(imagesToDelete));
         reviewRepository.delete(review);
+    }
+
+    private Volunteer getVolunteer(Long volunteerId) {
+        return volunteerRepository.findById(volunteerId)
+            .orElseThrow(() -> new VolunteerNotFoundException("존재하지 않는 봉사자입니다."));
     }
 
     private Review getReview(Long userId, Long reviewId) {

--- a/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
@@ -12,6 +12,7 @@ import com.clova.anifriends.domain.volunteer.vo.VolunteerGender;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerName;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerPassword;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerPhoneNumber;
+import com.clova.anifriends.domain.volunteer.vo.VolunteerReviewCount;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerTemperature;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -42,6 +43,7 @@ import lombok.NoArgsConstructor;
 public class Volunteer extends BaseTimeEntity {
 
     private static final String BLANK = "";
+    private static final int ZERO = 0;
 
     @Id
     @Column(name = "volunteer_id")
@@ -72,6 +74,9 @@ public class Volunteer extends BaseTimeEntity {
 
     @Embedded
     private VolunteerDeviceToken deviceToken;
+
+    @Embedded
+    private VolunteerReviewCount volunteerReviewCount = new VolunteerReviewCount(ZERO);
 
     @OneToMany(mappedBy = "volunteer", fetch = FetchType.LAZY)
     private List<Applicant> applicants = new ArrayList<>();
@@ -172,10 +177,16 @@ public class Volunteer extends BaseTimeEntity {
         this.temperature = this.temperature.decrease(temperature);
     }
 
+    public void increaseReviewCount() {
+        this.volunteerReviewCount = this.volunteerReviewCount.increase();
+    }
+
+    public void decreaseReviewCount() {
+        this.volunteerReviewCount = this.volunteerReviewCount.decrease();
+    }
+
     public long getReviewCount() {
-        return applicants.stream()
-            .filter(applicant -> Objects.nonNull(applicant.getReview()))
-            .count();
+        return volunteerReviewCount.getReviewCount();
     }
 
     public Long getVolunteerId() {

--- a/src/main/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCount.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCount.java
@@ -1,0 +1,33 @@
+package com.clova.anifriends.domain.volunteer.vo;
+
+import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
+import com.clova.anifriends.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.text.MessageFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VolunteerReviewCount {
+
+    private static final int ZERO = 0;
+
+    @Column(name = "review_count")
+    private int reviewCount;
+
+    public VolunteerReviewCount(int reviewCount) {
+        validateReviewCount(reviewCount);
+        this.reviewCount = reviewCount;
+    }
+
+    private void validateReviewCount(int reviewCount) {
+        if (reviewCount < ZERO) {
+            throw new VolunteerBadRequestException(ErrorCode.BAD_REQUEST,
+                MessageFormat.format("봉사자의 봉사 후기 개수는 {0} 이상이어야 합니다.", ZERO));
+        }
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCount.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCount.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class VolunteerReviewCount {
 
     private static final int ZERO = 0;
+    private static final int ONE = 1;
 
     @Column(name = "review_count")
     private int reviewCount;
@@ -29,5 +30,9 @@ public class VolunteerReviewCount {
             throw new VolunteerBadRequestException(ErrorCode.BAD_REQUEST,
                 MessageFormat.format("봉사자의 봉사 후기 개수는 {0} 이상이어야 합니다.", ZERO));
         }
+    }
+
+    public VolunteerReviewCount increase() {
+        return new VolunteerReviewCount(reviewCount + ONE);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCount.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCount.java
@@ -35,4 +35,8 @@ public class VolunteerReviewCount {
     public VolunteerReviewCount increase() {
         return new VolunteerReviewCount(reviewCount + ONE);
     }
+
+    public VolunteerReviewCount decrease() {
+        return new VolunteerReviewCount(reviewCount - ONE);
+    }
 }

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -17,10 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("dev")
 @Import({SecurityConfig.class, RedisConfig.class})
 public abstract class BaseIntegrationTest extends TestContainerStarter {
 

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -188,6 +188,7 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
             Shelter shelter = ShelterFixture.shelter();
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
             Volunteer volunteer = VolunteerFixture.volunteer();
+            volunteer.updateVolunteerInfo(null, null, null, null, "imageUrl");
             Applicant applicant = ApplicantFixture.applicant(recruitment, volunteer,
                 ApplicantStatus.ATTENDANCE);
             shelterRepository.save(shelter);
@@ -203,6 +204,7 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
                 shelter.getShelterId(), pageRequest);
 
             //then
+            assertThat(shelterReviewsByShelter.reviews()).hasSize(1);
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCountTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCountTest.java
@@ -1,0 +1,46 @@
+package com.clova.anifriends.domain.volunteer.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class VolunteerReviewCountTest {
+
+    @Nested
+    @DisplayName("VolunteerReviewCount 생성 시")
+    class NewVolunteerReviewCountTest {
+
+        @ParameterizedTest
+        @CsvSource({"0", "1", "10"})
+        @DisplayName("성공")
+        void newVolunteerReviewCount(String reviewCount) {
+            //given
+            int reviewCountNumber = Integer.parseInt(reviewCount);
+
+            //when
+            VolunteerReviewCount volunteerReviewCount = new VolunteerReviewCount(reviewCountNumber);
+
+            //then
+            assertThat(volunteerReviewCount.getReviewCount()).isEqualTo(reviewCountNumber);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"-1", "-5", "-10"})
+        @DisplayName("예외(VolunteerBadRequestException): 봉사 후기 개수가 음수")
+        void exceptionWhenInputInMinus(String reviewCount) {
+            //given
+            int reviewCountNumber = Integer.parseInt(reviewCount);
+
+            //when
+            Exception exception = catchException(() -> new VolunteerReviewCount(reviewCountNumber));
+
+            //then
+            assertThat(exception).isInstanceOf(VolunteerBadRequestException.class);
+        }
+    }
+}

--- a/src/test/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCountTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCountTest.java
@@ -63,4 +63,36 @@ class VolunteerReviewCountTest {
             assertThat(updatedVolunteerReviewCount).isNotSameAs(volunteerReviewCount);
         }
     }
+
+    @Nested
+    @DisplayName("decrease 메서드 호출 시")
+    class DecreaseTest {
+
+        @Test
+        @DisplayName("성공: 리뷰 개수가 1 감소한다.")
+        void decrease() {
+            //given
+            VolunteerReviewCount volunteerReviewCount = new VolunteerReviewCount(1);
+
+            //when
+            VolunteerReviewCount decreasedVolunteerCount = volunteerReviewCount.decrease();
+
+            //then
+            assertThat(decreasedVolunteerCount.getReviewCount()).isEqualTo(0);
+            assertThat(decreasedVolunteerCount).isNotSameAs(volunteerReviewCount);
+        }
+
+        @Test
+        @DisplayName("예외(VolunteerBadRequestException): 리뷰 개수는 0 보다 작아질 수 없다.")
+        void exceptionWhenTryDecreaseUnderZero() {
+            //given
+            VolunteerReviewCount volunteerReviewCount = new VolunteerReviewCount(0);
+
+            //when
+            Exception exception = catchException(volunteerReviewCount::decrease);
+
+            //then
+            assertThat(exception).isInstanceOf(VolunteerBadRequestException.class);
+        }
+    }
 }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCountTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/vo/VolunteerReviewCountTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.catchException;
 import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -41,6 +42,25 @@ class VolunteerReviewCountTest {
 
             //then
             assertThat(exception).isInstanceOf(VolunteerBadRequestException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("increase 메서드 호출 시")
+    class IncreaseTest {
+
+        @Test
+        @DisplayName("성공: 리뷰 개수가 1 증가한다.")
+        void increase() {
+            //given
+            VolunteerReviewCount volunteerReviewCount = new VolunteerReviewCount(0);
+
+            //when
+            VolunteerReviewCount updatedVolunteerReviewCount = volunteerReviewCount.increase();
+
+            //then
+            assertThat(updatedVolunteerReviewCount.getReviewCount()).isEqualTo(1);
+            assertThat(updatedVolunteerReviewCount).isNotSameAs(volunteerReviewCount);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자가 작성한 봉사 후기 개수에 대한 정보를 반정규화하였습니다.
- 후기 작성, 삭제 시에 증감하는 로직을 추가하였습니다.
- 내(보호소)가 받은 봉사 후기 목록 조회 시 n+1을 제거하였습니다.

### 📝 작업 요약
- 봉사자가 작성한 봉사 후기 개수(`VolunteerReviewCount`) vo 추가

### 💡 관련 이슈
- close #415 
