### PR TITLE
feat: 권한을 검증하지 않는 api 중 봉사자 이메일 응답을 마스킹한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/common/util/CommonBadRequestException.java
+++ b/src/main/java/com/clova/anifriends/domain/common/util/CommonBadRequestException.java
@@ -1,0 +1,11 @@
+package com.clova.anifriends.domain.common.util;
+
+import com.clova.anifriends.global.exception.BadRequestException;
+import com.clova.anifriends.global.exception.ErrorCode;
+
+public class CommonBadRequestException extends BadRequestException {
+
+    protected CommonBadRequestException(String message) {
+        super(ErrorCode.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/common/util/EmailMasker.java
+++ b/src/main/java/com/clova/anifriends/domain/common/util/EmailMasker.java
@@ -1,0 +1,23 @@
+package com.clova.anifriends.domain.common.util;
+
+import java.text.MessageFormat;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class EmailMasker {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+        "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final int OPEN_FIRST_INDEX = 0;
+    private static final int OPEN_LAST_INDEX = 4;
+
+    public static String masking(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new CommonBadRequestException("입력값이 이메일 형식이 아닙니다.");
+        }
+        String subEmail = email.substring(OPEN_FIRST_INDEX, OPEN_LAST_INDEX);
+        return MessageFormat.format("{0}****", subEmail);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsResponse.java
@@ -38,12 +38,10 @@ public record FindShelterReviewsResponse(
         Page<Review> reviewPage
     ) {
         PageInfo pageInfo = PageInfo.of(reviewPage.getTotalElements(), reviewPage.hasNext());
-
         List<FindShelterReviewByVolunteerResponse> reviews = reviewPage
             .map(FindShelterReviewByVolunteerResponse::from)
             .stream()
             .toList();
-
         return new FindShelterReviewsResponse(reviews, pageInfo);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/review/dto/response/FindShelterReviewsResponse.java
@@ -1,6 +1,7 @@
 package com.clova.anifriends.domain.review.dto.response;
 
 import com.clova.anifriends.domain.common.PageInfo;
+import com.clova.anifriends.domain.common.util.EmailMasker;
 import com.clova.anifriends.domain.review.Review;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,7 +29,7 @@ public record FindShelterReviewsResponse(
                 review.getApplicant().getVolunteer().getTemperature(),
                 review.getCreatedAt(),
                 review.getContent(),
-                review.getApplicant().getVolunteer().getEmail(),
+                EmailMasker.masking(review.getApplicant().getVolunteer().getEmail()),
                 review.getImages()
             );
         }

--- a/src/main/java/com/clova/anifriends/domain/review/service/ReviewService.java
+++ b/src/main/java/com/clova/anifriends/domain/review/service/ReviewService.java
@@ -83,7 +83,6 @@ public class ReviewService {
     ) {
         Page<Review> reviewPage
             = reviewRepository.findAllByShelterId(shelterId, pageable);
-
         return FindShelterReviewsResponse.from(reviewPage);
     }
 

--- a/src/test/java/com/clova/anifriends/domain/common/util/EmailMaskerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/common/util/EmailMaskerTest.java
@@ -1,0 +1,43 @@
+package com.clova.anifriends.domain.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class EmailMaskerTest {
+
+    @Nested
+    @DisplayName("masking 메서드 호출 시")
+    class MaskingTest {
+
+        @Test
+        @DisplayName("성공")
+        void masking() {
+            //given
+            String email = "email@email.com";
+
+            //when
+            String masking = EmailMasker.masking(email);
+
+            //then
+            assertThat(masking).isEqualTo("emai****");
+        }
+
+        @ParameterizedTest
+        @CsvSource({"asdf", "@.com"})
+        @DisplayName("예외(CommonBadRequestException): 입력값이 이메일 형식이 아님")
+        void exceptionWHenInputIsNotEmailPattern(String email) {
+            //given
+            //when
+            Exception exception = catchException(() -> EmailMasker.masking(email));
+
+            //then
+            assertThat(exception).isInstanceOf(CommonBadRequestException.class);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
권한이 필요하지 않은 API인 보호소의 리뷰 목록 조회 시 응답에 포함된 봉사자 이메일을 마스킹하는 로직을 추가하였습니다.

### 📝 작업 요약
- 봉사자 이메일 마스킹 로직 추가

### 💡 관련 이슈
- close #417 
