### PR TITLE
fix: 봉사 모집글 만료 스케줄링 간격을 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentDetailResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentDetailResponse.java
@@ -28,7 +28,7 @@ public record FindRecruitmentDetailResponse(
             recruitment.getContent(),
             recruitment.getStartTime(),
             recruitment.getEndTime(),
-            recruitment.isClosed() || recruitment.getDeadline().isBefore(LocalDateTime.now()),
+            recruitment.isClosed(),
             recruitment.getDeadline(),
             recruitment.getCreatedAt(),
             recruitment.getUpdatedAt(),

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsByShelterResponse.java
@@ -28,7 +28,7 @@ public record FindRecruitmentsByShelterResponse(
                 recruitment.getStartTime(),
                 recruitment.getEndTime(),
                 recruitment.getDeadline(),
-                recruitment.isClosed() || recruitment.getDeadline().isBefore(LocalDateTime.now()),
+                recruitment.isClosed(),
                 recruitment.getApplicantCount(),
                 recruitment.getCapacity()
             );

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
@@ -27,7 +27,8 @@ public record FindRecruitmentsResponse(
         int recruitmentApplicantCount,
         int recruitmentCapacity,
         String shelterName,
-        String shelterImageUrl) {
+        String shelterImageUrl,
+        LocalDateTime recruitmentCreatedAt) {
 
         public static FindRecruitmentResponse from(Recruitment recruitment) {
             return new FindRecruitmentResponse(
@@ -40,7 +41,8 @@ public record FindRecruitmentsResponse(
                 recruitment.getApplicantCount(),
                 recruitment.getCapacity(),
                 recruitment.getShelter().getName(),
-                recruitment.getShelter().getImage()
+                recruitment.getShelter().getImage(),
+                recruitment.getCreatedAt()
             );
         }
     }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
@@ -37,7 +37,7 @@ public record FindRecruitmentsResponse(
                 recruitment.getStartTime(),
                 recruitment.getEndTime(),
                 recruitment.getDeadline(),
-                recruitment.isClosed() || recruitment.getDeadline().isBefore(LocalDateTime.now()),
+                recruitment.isClosed(),
                 recruitment.getApplicantCount(),
                 recruitment.getCapacity(),
                 recruitment.getShelter().getName(),

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -54,5 +55,9 @@ public interface RecruitmentRepository
     List<Recruitment> findRecruitmentsByEndTime(@Param("time1") LocalDateTime time1,
         @Param("time2") LocalDateTime time2);
 
-    List<Recruitment> findByInfo_IsClosedFalseAndInfo_DeadlineBefore(LocalDateTime deadline);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update Recruitment r set r.info.isClosed = true"
+        + " where r.info.isClosed = false"
+        + " and r.info.deadline <= now()")
+    void closeRecruitmentsIfNeedToBe();
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -283,10 +283,7 @@ public class RecruitmentService {
 
     @Transactional
     public void autoCloseRecruitment() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Recruitment> recruitments = recruitmentRepository
-            .findByInfo_IsClosedFalseAndInfo_DeadlineBefore(now);
-        recruitments.forEach(Recruitment::closeRecruitment);
-        recruitments.forEach(recruitmentCacheRepository::update);
+        recruitmentRepository.closeRecruitmentsIfNeedToBe();
+        recruitmentCacheRepository.closeRecruitmentsIfNeedToBe();
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -190,6 +190,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
         Shelter shelter = shelter();
         Recruitment recruitment = recruitment(shelter);
         ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
+        ReflectionTestUtils.setField(recruitment, "createdAt", LocalDateTime.now());
         FindRecruitmentResponse findRecruitmentResponse
             = FindRecruitmentResponse.from(recruitment);
         PageInfo pageInfo = new PageInfo(1, false);
@@ -245,6 +246,8 @@ class RecruitmentControllerTest extends BaseControllerTest {
                     fieldWithPath("recruitments[].shelterName").type(STRING).description("보호소 이름"),
                     fieldWithPath("recruitments[].shelterImageUrl").type(STRING)
                         .description("보호소 이미지 url").optional(),
+                    fieldWithPath("recruitments[].recruitmentCreatedAt").type(STRING)
+                        .description("봉사 모집글 생성 시간"),
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
                     fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),
                     fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부")
@@ -269,6 +272,7 @@ class RecruitmentControllerTest extends BaseControllerTest {
         Shelter shelter = shelter();
         Recruitment recruitment = recruitment(shelter);
         ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
+        ReflectionTestUtils.setField(recruitment, "createdAt", LocalDateTime.now());
         FindRecruitmentResponse findRecruitmentResponse
             = FindRecruitmentResponse.from(recruitment);
         PageInfo pageInfo = new PageInfo(1, false);
@@ -326,6 +330,8 @@ class RecruitmentControllerTest extends BaseControllerTest {
                     fieldWithPath("recruitments[].shelterName").type(STRING).description("보호소 이름"),
                     fieldWithPath("recruitments[].shelterImageUrl").type(STRING)
                         .description("보호소 이미지 url").optional(),
+                    fieldWithPath("recruitments[].recruitmentCreatedAt").type(STRING)
+                        .description("봉사 모집글 생성 시간"),
                     fieldWithPath("pageInfo").type(OBJECT).description("페이지 정보"),
                     fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 요소 개수"),
                     fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 여부")

--- a/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepositoryTest.java
@@ -6,6 +6,7 @@ import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
+import com.clova.anifriends.domain.recruitment.vo.RecruitmentInfo;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
@@ -135,7 +137,8 @@ class RecruitmentCacheRepositoryTest extends BaseIntegrationTest {
             PageRequest pageRequest = PageRequest.of(0, 20);
 
             //when
-            Slice<FindRecruitmentResponse> recruitments = recruitmentCacheRepository.findAll(pageRequest);
+            Slice<FindRecruitmentResponse> recruitments = recruitmentCacheRepository.findAll(
+                pageRequest);
 
             //then
             assertThat(recruitments.getContent())
@@ -348,6 +351,54 @@ class RecruitmentCacheRepositoryTest extends BaseIntegrationTest {
             Set<FindRecruitmentResponse> recruitments = cachedRecruitments.rangeByScore(
                 RECRUITMENT_KEY, createdAtScore, createdAtScore);
             assertThat(recruitments).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("closeRecruitmentsIfNeedToBe 메서드 호출 시")
+    class CloseRecruitmentsIfNeedToBeTest {
+
+        Shelter shelter;
+
+        @BeforeEach
+        void setUp() {
+            shelter = ShelterFixture.shelter();
+            shelterRepository.save(shelter);
+        }
+
+        @Test
+        @DisplayName("성공: A(마감 대상), B(대상 아님)")
+        void closeRecruitmentsIfNeedToBe() {
+            //given
+            Recruitment recruitmentB = RecruitmentFixture.recruitment(shelter);
+            Recruitment recruitmentA = RecruitmentFixture.recruitment(shelter);
+            RecruitmentInfo recruitmentInfo = new RecruitmentInfo(recruitmentA.getStartTime(),
+                recruitmentA.getEndTime(), recruitmentA.getDeadline(), recruitmentA.isClosed(),
+                recruitmentA.getCapacity());
+            LocalDateTime deadlineBeforeNow = LocalDateTime.now().minusDays(1);
+            ReflectionTestUtils.setField(recruitmentInfo, "deadline", deadlineBeforeNow);
+            ReflectionTestUtils.setField(recruitmentA, "info", recruitmentInfo);
+            recruitmentRepository.save(recruitmentA);
+            recruitmentRepository.save(recruitmentB);
+            recruitmentCacheRepository.save(recruitmentA);
+            recruitmentCacheRepository.save(recruitmentB);
+
+            //when
+            recruitmentCacheRepository.closeRecruitmentsIfNeedToBe();
+
+            //then
+            Set<FindRecruitmentResponse> cachedRecruitments = redisTemplate.opsForZSet()
+                .range(RECRUITMENT_KEY, ZERO, ALL_ELEMENT);
+            Optional<FindRecruitmentResponse> findRecruitmentA = cachedRecruitments.stream()
+                .filter(FindRecruitmentResponse::recruitmentIsClosed)
+                .findFirst();
+            Optional<FindRecruitmentResponse> findRecruitmentB = cachedRecruitments.stream()
+                .filter(recruitment -> !recruitment.recruitmentIsClosed())
+                .findFirst();
+            assertThat(findRecruitmentA).isNotEmpty();
+            assertThat(findRecruitmentB).isNotEmpty();
+            assertThat(findRecruitmentA.get().recruitmentIsClosed()).isTrue();
+            assertThat(findRecruitmentB.get().recruitmentIsClosed()).isFalse();
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -36,11 +36,8 @@ import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
-import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -689,30 +686,16 @@ class RecruitmentServiceTest {
     @DisplayName("autoCloseRecruitment 메서드 호출 시")
     class AutoCloseRecruitmentTest {
 
-            @Test
-            @DisplayName("성공")
-            void autoCloseRecruitment() {
-                //given
-                Instant fixedInstant = Instant.parse("2025-01-01T12:00:00Z");
-                Clock fixedClock = Clock.fixed(fixedInstant, ZoneId.systemDefault());
-                LocalDateTime mockNow = LocalDateTime.now(fixedClock);
+        @Test
+        @DisplayName("성공: repository 호출, 캐시 repository 호출")
+        void autoCloseRecruitment() {
+            //given
+            //when
+            recruitmentService.autoCloseRecruitment();
 
-                Shelter shelter = shelter();
-                Recruitment recruitment = recruitment(shelter);
-                ReflectionTestUtils.setField(recruitment, "recruitmentId", 1L);
-                List<Recruitment> recruitments = List.of(recruitment);
-                recruitment.updateRecruitment(
-                    null, null, null, LocalDateTime.now().plusHours(1), null, null, null
-                );
-
-                when(recruitmentRepository.findByInfo_IsClosedFalseAndInfo_DeadlineBefore(any()))
-                    .thenReturn(recruitments);
-
-                //when
-                recruitmentService.autoCloseRecruitment();
-
-                //then
-                assertThat(recruitment.isClosed()).isTrue();
-            }
+            //then
+            then(recruitmentRepository).should().closeRecruitmentsIfNeedToBe();
+            then(recruitmentCacheRepository).should().closeRecruitmentsIfNeedToBe();
+        }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사 모집글 자동 만료 스케줄링 간격을 하루에 한번에서 매분마다로 변경하였습니다.
- 봉사 모집글 자동 만료 로직을 일부 수정하였습니다.

### 📝 작업 요약
- 봉사 모집글 자동 만료 스케줄링 크론 표현식 수정
- 해당 로직 일부 수정

### 💡 관련 이슈
- close #419 
