### PR TITLE
fix: 내(보호소)가 받은 리뷰 목록 조회 batchSize가 적용되지 않는 문제를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/review/repository/ReviewRepository.java
@@ -35,7 +35,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r from Review r"
         + " join fetch r.applicant a"
         + " join fetch a.volunteer v"
-        + " left join fetch r.images"
         + " left join fetch v.image"
         + " where r.applicant.recruitment.shelter = :shelter")
     Page<Review> findShelterReviewsByShelter(@Param("shelter") Shelter shelter,

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -186,17 +186,24 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
         void findShelterReviewsByShelter() {
             //given
             Shelter shelter = ShelterFixture.shelter();
-            Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
+            Recruitment recruitmentA = RecruitmentFixture.recruitment(shelter);
+            Recruitment recruitmentB = RecruitmentFixture.recruitment(shelter);
             Volunteer volunteer = VolunteerFixture.volunteer();
             volunteer.updateVolunteerInfo(null, null, null, null, "imageUrl");
-            Applicant applicant = ApplicantFixture.applicant(recruitment, volunteer,
+            Applicant applicantA = ApplicantFixture.applicant(recruitmentA, volunteer,
+                ApplicantStatus.ATTENDANCE);
+            Applicant applicantB = ApplicantFixture.applicant(recruitmentB, volunteer,
                 ApplicantStatus.ATTENDANCE);
             shelterRepository.save(shelter);
-            recruitmentRepository.save(recruitment);
+            recruitmentRepository.save(recruitmentA);
+            recruitmentRepository.save(recruitmentB);
             volunteerRepository.save(volunteer);
-            applicantRepository.save(applicant);
-            Review review = ReviewFixture.review(applicant);
-            reviewRepository.save(review);
+            applicantRepository.save(applicantA);
+            applicantRepository.save(applicantB);
+            Review reviewA = ReviewFixture.review(applicantA);
+            Review reviewB = ReviewFixture.review(applicantB);
+            reviewRepository.save(reviewA);
+            reviewRepository.save(reviewB);
             PageRequest pageRequest = PageRequest.of(0, 10);
 
             //when
@@ -204,7 +211,7 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
                 shelter.getShelterId(), pageRequest);
 
             //then
-            assertThat(shelterReviewsByShelter.reviews()).hasSize(1);
+            assertThat(shelterReviewsByShelter.reviews()).hasSize(2);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 내(보호소)가 받은 리뷰 목록 조회 쿼리가 컬렉션을 left join 하지 않도록 변경하였습니다.
- batchSize가 정상 적용되는 것을 확인하였습니다.

### 📝 작업 요약
- 내(보호소)가 받은 리뷰 목록 조회 쿼리 수정

### 💡 관련 이슈
- close #421 
