### PR TITLE
refactor: AOP 순서를 지정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/global/aspect/DataIntegrityAspect.java
+++ b/src/main/java/com/clova/anifriends/global/aspect/DataIntegrityAspect.java
@@ -3,10 +3,12 @@ package com.clova.anifriends.global.aspect;
 import com.clova.anifriends.global.exception.ErrorCode;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Aspect
+@Order(2)
 @Component
 public class DataIntegrityAspect {
 

--- a/src/main/java/com/clova/anifriends/global/aspect/LogAspect.java
+++ b/src/main/java/com/clova/anifriends/global/aspect/LogAspect.java
@@ -7,18 +7,22 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Aspect
+@Order(1)
 @Component
 public class LogAspect {
 
     @Pointcut("bean(*Service)")
-    private void allService(){}
+    private void allService() {
+    }
 
     @Pointcut("bean(*Controller)")
-    private void allRequest(){}
+    private void allRequest() {
+    }
 
     @AfterThrowing(pointcut = "allService()", throwing = "ex")
     private void logException(JoinPoint joinPoint, RuntimeException ex) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,6 +23,11 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+  output:
+    ansi:
+      enabled: always
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
### ⛏ 작업 사항
- `DataIntegrityAspect`, `LogAspect` 의 순서 설정

### 📝 작업 요약
- `DataIntegrityAspect` 는 @Order(1) 로 설정
- `LogAspect` 는 @Order(2) 로 설정

#### 변경 전 로그
<img width="1283" alt="스크린샷 2023-12-15 오후 7 15 04" src="https://github.com/Anifriends/Anifriends-Backend/assets/97938489/5fb98525-1724-4735-b518-4cbe2c0a4a7a">

#### 변경 후 로그
<img width="1257" alt="스크린샷 2023-12-15 오후 7 20 46" src="https://github.com/Anifriends/Anifriends-Backend/assets/97938489/ff60dd00-88a0-4005-86fb-7ba5d74911ff">


### 💡 관련 이슈
- close #436 
