### PR TITLE
fix: 봉사자 이미지 업데이트 시 기존 이미지 엔티티가 제거되지 않는 문제를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/shelter/Shelter.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/Shelter.java
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.Optional;
@@ -54,8 +55,8 @@ public class Shelter extends BaseTimeEntity {
     @Embedded
     private ShelterDeviceToken deviceToken;
 
-    @OneToOne(mappedBy = "shelter", fetch = FetchType.LAZY,
-        cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "shelter_image_id")
     private ShelterImage image;
 
     public Shelter(
@@ -92,11 +93,11 @@ public class Shelter extends BaseTimeEntity {
     }
 
     private ShelterImage updateImage(String imageUrl) {
-        if(nonNull(imageUrl)) {
-            if(imageUrl.isBlank()) {
+        if (nonNull(imageUrl)) {
+            if (imageUrl.isBlank()) {
                 return null;
             }
-            if(nonNull(image) && image.isSameWith(imageUrl)) {
+            if (nonNull(image) && image.isSameWith(imageUrl)) {
                 return image;
             }
             return new ShelterImage(this, imageUrl);

--- a/src/main/java/com/clova/anifriends/domain/shelter/ShelterImage.java
+++ b/src/main/java/com/clova/anifriends/domain/shelter/ShelterImage.java
@@ -3,11 +3,9 @@ package com.clova.anifriends.domain.shelter;
 import com.clova.anifriends.domain.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -25,8 +23,7 @@ public class ShelterImage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long shelterImageId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "shelter_id")
+    @OneToOne(mappedBy = "image")
     private Shelter shelter;
 
     @Column(name = "image_url")

--- a/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/Volunteer.java
@@ -24,6 +24,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -81,7 +82,8 @@ public class Volunteer extends BaseTimeEntity {
     @OneToMany(mappedBy = "volunteer", fetch = FetchType.LAZY)
     private List<Applicant> applicants = new ArrayList<>();
 
-    @OneToOne(mappedBy = "volunteer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @JoinColumn(name = "volunteer_image_id")
     private VolunteerImage image;
 
     public Volunteer(

--- a/src/main/java/com/clova/anifriends/domain/volunteer/VolunteerImage.java
+++ b/src/main/java/com/clova/anifriends/domain/volunteer/VolunteerImage.java
@@ -5,11 +5,9 @@ import com.clova.anifriends.domain.volunteer.exception.VolunteerBadRequestExcept
 import com.clova.anifriends.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -27,8 +25,7 @@ public class VolunteerImage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long volunteerImageId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "volunteer_id")
+    @OneToOne(mappedBy = "image")
     private Volunteer volunteer;
 
     @Column(name = "image_url")

--- a/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/shelter/service/ShelterIntegrationTest.java
@@ -6,6 +6,7 @@ import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.common.CustomPasswordEncoder;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.dto.response.RegisterShelterResponse;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,41 @@ public class ShelterIntegrationTest extends BaseIntegrationTest {
             boolean isPasswordUpdated
                 = passwordEncoder.matchesPassword(newRawPassword, findShelter.getPassword());
             assertThat(isPasswordUpdated).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateShelterInfo 메서드 호출 시")
+    class UpdateShelterInfo {
+
+        @Test
+        @DisplayName("성공: 이미지 url 입력값이 들어왔고, 기존의 봉사자 이미지와 다르다면 shelterImage 가 새롭게 생성된다.")
+        void updateShelterInfoWhenDifferentFromCurrentImage() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            shelterRepository.save(shelter);
+
+            String beforeImage = "beforeImage.jpg";
+            String afterImage = "afterImage.jpg";
+
+            shelterService.updateShelter(shelter.getShelterId(), shelter.getName(),
+                beforeImage, shelter.getAddress(), shelter.getAddressDetail(),
+                shelter.getPhoneNumber(), shelter.getSparePhoneNumber(),
+                shelter.isOpenedAddress());
+
+            // when
+            shelterService.updateShelter(shelter.getShelterId(), shelter.getName(),
+                afterImage, shelter.getAddress(), shelter.getAddressDetail(),
+                shelter.getPhoneNumber(), shelter.getSparePhoneNumber(),
+                shelter.isOpenedAddress());
+
+            // then
+            Shelter updatedShelter = entityManager.createQuery(
+                    "select s from Shelter s join fetch s.image where s.shelterId = :shelterId",
+                    Shelter.class)
+                .setParameter("shelterId", shelter.getShelterId())
+                .getSingleResult();
+            assertThat(updatedShelter.getImage()).isEqualTo(afterImage);
         }
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/volunteer/service/VolunteerIntegrationTest.java
@@ -64,7 +64,11 @@ public class VolunteerIntegrationTest extends BaseIntegrationTest {
 
             //then
             Volunteer updatedVolunteer
-                = entityManager.find(Volunteer.class, givenVolunteerId);
+                = entityManager.createQuery(
+                    "select v from Volunteer v join fetch v.image where v.volunteerId = :volunteerId",
+                    Volunteer.class)
+                .setParameter("volunteerId", givenVolunteerId)
+                .getSingleResult();
             assertThat(updatedVolunteer.getName()).isEqualTo(newName);
             assertThat(updatedVolunteer.getGender()).isEqualTo(newGender);
             assertThat(updatedVolunteer.getBirthDate()).isEqualTo(newBirthDate);
@@ -89,6 +93,30 @@ public class VolunteerIntegrationTest extends BaseIntegrationTest {
                     "select vi from VolunteerImage vi", VolunteerImage.class)
                 .getResultList();
             assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("성공: 이미지 url 입력값이 들어왔고, 기존의 봉사자 이미지와 다르다면 volunteerImage 가 새롭게 생성된다.")
+        void updateVolunteerInfoWhenDifferentFromCurrentImage() {
+            //given
+            String beforeImage = "beforeImage.jpg";
+            String afterImage = "afterImage.jpg";
+            volunteerService.updateVolunteerInfo(givenVolunteerId, volunteer.getName(),
+                volunteer.getGender(), volunteer.getBirthDate(), volunteer.getPhoneNumber(),
+                beforeImage);
+
+            //when
+            volunteerService.updateVolunteerInfo(givenVolunteerId, volunteer.getName(),
+                volunteer.getGender(), volunteer.getBirthDate(), volunteer.getPhoneNumber(),
+                afterImage);
+
+            //then
+            Volunteer updatedVolunteer = entityManager.createQuery(
+                    "select v from Volunteer v join fetch v.image where v.volunteerId = :volunteerId",
+                    Volunteer.class)
+                .setParameter("volunteerId", givenVolunteerId)
+                .getSingleResult();
+            assertThat(updatedVolunteer.getVolunteerImageUrl()).isEqualTo(afterImage);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- OneToOne 연관관계를 갖는 volunteer / volunteer_image, shelter/shelter_image 의 외래키를 주테이블에서 관리하도록 수정 (프로필 이미지의 경우, 항상 주테이블인 volunteer 나 shelter 를 통해 접근하기 때문에 외래키를 주테이블에서 관리하도록 수정하는게 옳은 방향이라 생각했습니다.)

### 📝 작업 요약
1. 봉사자나 보호소가 프로필 수정을 하면 flush 될 때 새로운 이미지의 insert 쿼리가 먼저 실행되어 volunteer_id FK unique 제약 조건 위반 예외가 발생하였습니다. FK 를 주 테이블인 volunteer / shelter 가 관리하도록 설정하여 다음과 같이 `새로운 image insert` -> `기존의 주 테이블 update` -> `기존의 image delete` 로 실행되도록 수정하였습니다.
2. 연관관계가 제거될 시 image 가 함께 삭제되도록 `orphanRemoval = true` 를 설정하였습니다.

<img width="300" alt="스크린샷 2023-12-26 오후 5 32 12" src="https://github.com/anifriends/Anifriends-Backend/assets/97938489/08a37d75-460c-49f8-8d5a-4e613551360c">

### 💡 관련 이슈
- close #424 
