### PR TITLE
refactor: S3 에서 이미지를 삭제하는 로직을 비동기적으로 동작하도록 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/common/event/ImageDeletionListener.java
+++ b/src/main/java/com/clova/anifriends/domain/common/event/ImageDeletionListener.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.common.event;
 
 import com.clova.anifriends.domain.common.ImageRemover;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,6 +13,7 @@ public class ImageDeletionListener {
 
     private final ImageRemover imageRemover;
 
+    @Async("asyncImageRemoverExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleImageDeletionEvent(ImageDeletionEvent imageDeletionEvent) {
         imageRemover.deleteImages(imageDeletionEvent.imageUrls());

--- a/src/main/java/com/clova/anifriends/global/config/AsyncConfig.java
+++ b/src/main/java/com/clova/anifriends/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.clova.anifriends.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "asyncImageRemoverExecutor")
+    public Executor asyncImageRemoverExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(10);
+        taskExecutor.setMaxPoolSize(30);
+        taskExecutor.setQueueCapacity(100);
+        taskExecutor.setThreadNamePrefix("Executor-");
+        return taskExecutor;
+    }
+
+}

--- a/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseIntegrationTest.java
@@ -21,8 +21,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
 @SpringBootTest
+@RecordApplicationEvents
 @Import({SecurityConfig.class, RedisConfig.class})
 public abstract class BaseIntegrationTest extends TestContainerStarter {
 
@@ -31,6 +34,9 @@ public abstract class BaseIntegrationTest extends TestContainerStarter {
 
     @Autowired
     DatabaseCleaner databaseCleaner;
+
+    @Autowired
+    protected ApplicationEvents events;
 
     @Autowired
     protected VolunteerRepository volunteerRepository;

--- a/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/animal/service/AnimalServiceIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.clova.anifriends.domain.animal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.animal.Animal;
@@ -20,6 +18,7 @@ import com.clova.anifriends.domain.animal.vo.AnimalActive;
 import com.clova.anifriends.domain.animal.vo.AnimalGender;
 import com.clova.anifriends.domain.animal.vo.AnimalNeuteredFilter;
 import com.clova.anifriends.domain.animal.vo.AnimalType;
+import com.clova.anifriends.domain.common.event.ImageDeletionEvent;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.support.ShelterFixture;
 import java.time.LocalDate;
@@ -123,7 +122,7 @@ public class AnimalServiceIntegrationTest extends BaseIntegrationTest {
             animalService.deleteAnimal(shelter.getShelterId(), animal.getAnimalId());
 
             //then
-            verify(s3Service, times(1)).deleteImages(imageUrls);
+            assertThat(events.stream(ImageDeletionEvent.class).count()).isEqualTo(1);
             Animal findAnimal = entityManager.find(Animal.class, animal.getAnimalId());
             assertThat(findAnimal).isNull();
             List<AnimalImage> findAnimalImages = entityManager.createQuery(

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
@@ -1,11 +1,10 @@
 package com.clova.anifriends.domain.recruitment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.applicant.Applicant;
+import com.clova.anifriends.domain.common.event.ImageDeletionEvent;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.RecruitmentImage;
 import com.clova.anifriends.domain.recruitment.controller.RecruitmentStatusFilter;
@@ -144,7 +143,7 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
                 recruitment.getRecruitmentId());
 
             //then
-            verify(s3Service, times(1)).deleteImages(imageUrls);
+            assertThat(events.stream(ImageDeletionEvent.class).count()).isEqualTo(1);
             Recruitment findRecruitment = entityManager.find(Recruitment.class,
                 recruitment.getRecruitmentId());
             assertThat(findRecruitment).isNull();

--- a/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/review/service/ReviewIntegrationTest.java
@@ -2,13 +2,12 @@ package com.clova.anifriends.domain.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.clova.anifriends.base.BaseIntegrationTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
+import com.clova.anifriends.domain.common.event.ImageDeletionEvent;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
 import com.clova.anifriends.domain.review.Review;
@@ -68,7 +67,7 @@ public class ReviewIntegrationTest extends BaseIntegrationTest {
             reviewService.deleteReview(volunteer.getVolunteerId(), review.getReviewId());
 
             //then
-            verify(s3Service, times(1)).deleteImages(List.of("image1", "image2"));
+            assertThat(events.stream(ImageDeletionEvent.class).count()).isEqualTo(1);
 
         }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- `@Async` 를 사용하여 S3 이미지 삭제 로직이 비동기적으로 동작하도록 수정

### 📝 작업 요약
- `ImageDeletionEvent` 에 적용할 `asyncImageRemoverExecutor` 설정
- `@RecordApplicationEvents` 를 사용하여 비동기 이벤트 호출 여부 테스트

### 💡 관련 이슈
- close #444
