### PR TITLE
refactor: findApprovedApplicants의 N+1 쿼리를 개선한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/applicant/dto/response/FindApprovedApplicantsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/dto/response/FindApprovedApplicantsResponse.java
@@ -6,10 +6,10 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record FindApprovedApplicantsResponse(
-    List<FindApplicant> applicants
+    List<FindApprovedApplicantResponse> applicants
 ) {
 
-    private record FindApplicant(
+    public record FindApprovedApplicantResponse(
         Long volunteerId,
         Long applicantId,
         String volunteerName,
@@ -19,8 +19,8 @@ public record FindApprovedApplicantsResponse(
         boolean volunteerAttendance
     ) {
 
-        private static FindApplicant from(Applicant applicant) {
-            return new FindApplicant(
+        public static FindApprovedApplicantResponse from(Applicant applicant) {
+            return new FindApprovedApplicantResponse(
                 applicant.getVolunteer().getVolunteerId(),
                 applicant.getApplicantId(),
                 applicant.getVolunteer().getName(),
@@ -31,13 +31,4 @@ public record FindApprovedApplicantsResponse(
             );
         }
     }
-
-    public static FindApprovedApplicantsResponse from(List<Applicant> applicants) {
-        return new FindApprovedApplicantsResponse(
-            applicants.stream()
-                .map(FindApplicant::from)
-                .toList()
-        );
-    }
-
 }

--- a/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepository.java
@@ -3,6 +3,7 @@ package com.clova.anifriends.domain.applicant.repository;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplicantResult;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplyingVolunteerResult;
+import com.clova.anifriends.domain.applicant.repository.response.FindApprovedApplicantsResult;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.shelter.Shelter;
@@ -44,15 +45,26 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
         @Param("volunteerId") Long volunteerId
     );
 
-    @Query("select a from Applicant a "
-        + "join fetch a.recruitment r "
-        + "join fetch r.shelter s "
-        + "join fetch a.volunteer v "
-        + "where r.recruitmentId = :recruitmentId "
-        + "and s.shelterId = :shelterId "
-        + "and (a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE "
-        + "or a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW)")
-    List<Applicant> findApprovedApplicants(
+    @Query(
+        """
+                select v.volunteerId as volunteerId,
+                    a.applicantId as applicantId,
+                    v.name.name as volunteerName,
+                    v.birthDate as volunteerBirthDate,
+                    v.gender as volunteerGender,
+                    v.phoneNumber.phoneNumber as volunteerPhoneNumber,
+                    a.status as applicantStatus
+                from Applicant a
+                join a.volunteer v
+                join a.recruitment.shelter s
+                join a.recruitment r
+                where r.recruitmentId = :recruitmentId
+                and s.shelterId = :shelterId
+                and a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.ATTENDANCE
+                or a.status = com.clova.anifriends.domain.applicant.vo.ApplicantStatus.NOSHOW
+            """
+    )
+    List<FindApprovedApplicantsResult> findApprovedApplicants(
         @Param("recruitmentId") Long recruitmentId,
         @Param("shelterId") Long shelterId
     );

--- a/src/main/java/com/clova/anifriends/domain/applicant/repository/response/FindApprovedApplicantsResult.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/repository/response/FindApprovedApplicantsResult.java
@@ -1,0 +1,22 @@
+package com.clova.anifriends.domain.applicant.repository.response;
+
+import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
+import com.clova.anifriends.domain.volunteer.vo.VolunteerGender;
+import java.time.LocalDate;
+
+public interface FindApprovedApplicantsResult {
+
+    Long getVolunteerId();
+
+    Long getApplicantId();
+
+    String getVolunteerName();
+
+    LocalDate getVolunteerBirthDate();
+
+    VolunteerGender getVolunteerGender();
+
+    String getVolunteerPhoneNumber();
+
+    ApplicantStatus getApplicantStatus();
+}

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantMapper.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantMapper.java
@@ -4,8 +4,12 @@ import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse;
 import com.clova.anifriends.domain.applicant.dto.FindApplicantsResponse.FindApplicantResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse.FindApplyingVolunteerResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse.FindApprovedApplicantResponse;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplicantResult;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplyingVolunteerResult;
+import com.clova.anifriends.domain.applicant.repository.response.FindApprovedApplicantsResult;
+import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.common.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import java.util.List;
@@ -49,5 +53,24 @@ public final class ApplicantMapper {
             ))
             .toList();
         return new FindApplicantsResponse(responses, recruitment.getCapacity());
+    }
+
+    public static FindApprovedApplicantsResponse resultToResponse(
+        List<FindApprovedApplicantsResult> applicantsApproved
+    ) {
+        List<FindApprovedApplicantResponse> response = applicantsApproved.stream()
+            .map(findApprovedApplicantsResult -> new FindApprovedApplicantResponse(
+                    findApprovedApplicantsResult.getVolunteerId(),
+                    findApprovedApplicantsResult.getApplicantId(),
+                    findApprovedApplicantsResult.getVolunteerName(),
+                    findApprovedApplicantsResult.getVolunteerBirthDate(),
+                    findApprovedApplicantsResult.getVolunteerGender(),
+                    findApprovedApplicantsResult.getVolunteerPhoneNumber(),
+                    findApprovedApplicantsResult.getApplicantStatus().equals(ApplicantStatus.ATTENDANCE)
+                )
+            )
+            .toList();
+
+        return new FindApprovedApplicantsResponse(response);
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/clova/anifriends/domain/applicant/service/ApplicantService.java
@@ -8,6 +8,7 @@ import com.clova.anifriends.domain.applicant.exception.ApplicantCanNotApplyExcep
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplicantResult;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplyingVolunteerResult;
+import com.clova.anifriends.domain.applicant.repository.response.FindApprovedApplicantsResult;
 import com.clova.anifriends.domain.applicant.service.dto.UpdateApplicantAttendanceCommand;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.notification.ShelterNotification;
@@ -16,9 +17,9 @@ import com.clova.anifriends.domain.notification.repository.ShelterNotificationRe
 import com.clova.anifriends.domain.notification.repository.VolunteerNotificationRepository;
 import com.clova.anifriends.domain.notification.vo.NotificationType;
 import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.dto.response.IsAppliedRecruitmentResponse;
 import com.clova.anifriends.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
-import com.clova.anifriends.domain.recruitment.dto.response.IsAppliedRecruitmentResponse;
 import com.clova.anifriends.domain.review.exception.ApplicantNotFoundException;
 import com.clova.anifriends.domain.shelter.Shelter;
 import com.clova.anifriends.domain.shelter.exception.ShelterNotFoundException;
@@ -78,9 +79,9 @@ public class ApplicantService {
     @Transactional(readOnly = true)
     public FindApprovedApplicantsResponse findApprovedApplicants(Long shelterId,
         Long recruitmentId) {
-        List<Applicant> applicantsApproved = applicantRepository
+        List<FindApprovedApplicantsResult> applicantsApproved = applicantRepository
             .findApprovedApplicants(recruitmentId, shelterId);
-        return FindApprovedApplicantsResponse.from(applicantsApproved);
+        return ApplicantMapper.resultToResponse(applicantsApproved);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/clova/anifriends/domain/applicant/ApplicantTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/ApplicantTest.java
@@ -49,6 +49,7 @@ class ApplicantTest {
 
             //then
             assertThat(applicant.getRecruitment()).isEqualTo(recruitment);
+            assertThat(applicant.isAttendance()).isEqualTo(false);
         }
 
         @Test

--- a/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/controller/ApplicantControllerTest.java
@@ -35,6 +35,7 @@ import com.clova.anifriends.domain.applicant.dto.request.UpdateApplicantsAttenda
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApplyingVolunteersResponse.FindApplyingVolunteerResponse;
 import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse;
+import com.clova.anifriends.domain.applicant.dto.response.FindApprovedApplicantsResponse.FindApprovedApplicantResponse;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.common.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
@@ -149,10 +150,18 @@ class ApplicantControllerTest extends BaseControllerTest {
     @DisplayName("봉사 신청 승인자 조회 API 호출 시")
     void findApprovedApplicants() throws Exception {
         // given
-        FindApprovedApplicantsResponse.from(List.of());
+        FindApprovedApplicantResponse findApprovedApplicantResponse = new FindApprovedApplicantResponse(
+            1L,
+            2L,
+            "김이름",
+            LocalDate.now(),
+            VolunteerGender.MALE,
+            "010-2382-1832",
+            true
+        );
 
         when(applicantService.findApprovedApplicants(anyLong(), anyLong()))
-            .thenReturn(FindApprovedApplicantsResponse.from(List.of()));
+            .thenReturn(new FindApprovedApplicantsResponse(List.of(findApprovedApplicantResponse)));
 
         // when
         ResultActions result = mockMvc.perform(
@@ -174,7 +183,8 @@ class ApplicantControllerTest extends BaseControllerTest {
                         fieldWithPath("applicants[]").type(ARRAY).description("봉사 신청자 리스트").optional(),
                         fieldWithPath("applicants[].applicantId").type(NUMBER).description("봉사 신청 ID"),
                         fieldWithPath("applicants[].volunteerId").type(NUMBER).description("봉사자 ID"),
-                        fieldWithPath("applicants[].volunteerBirthdate").type(STRING)
+                        fieldWithPath("applicants[].volunteerName").type(STRING).description("봉사자 이름"),
+                        fieldWithPath("applicants[].volunteerBirthDate").type(STRING)
                             .description("봉사자 생일"),
                         fieldWithPath("applicants[].volunteerGender").type(STRING)
                             .description("봉사자 성별"),

--- a/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -15,6 +15,7 @@ import com.clova.anifriends.base.BaseRepositoryTest;
 import com.clova.anifriends.domain.applicant.Applicant;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplicantResult;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplyingVolunteerResult;
+import com.clova.anifriends.domain.applicant.repository.response.FindApprovedApplicantsResult;
 import com.clova.anifriends.domain.applicant.support.ApplicantFixture;
 import com.clova.anifriends.domain.recruitment.Recruitment;
 import com.clova.anifriends.domain.recruitment.support.fixture.RecruitmentFixture;
@@ -70,12 +71,12 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             List<Applicant> expected = List.of(applicantAttendance, applicantNoShow);
 
             // when
-            List<Applicant> result = applicantRepository
+            List<FindApprovedApplicantsResult> result = applicantRepository
                 .findApprovedApplicants(recruitment.getRecruitmentId(),
                     shelter.getShelterId());
 
             // then
-            assertThat(result).isEqualTo(expected);
+            assertThat(result.size()).isEqualTo(expected.size());
         }
 
         @Test
@@ -97,15 +98,16 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
             applicantRepository.saveAll(
                 List.of(applicantPending, applicantRefused)
             );
+
             List<Applicant> expected = List.of();
 
             // when
-            List<Applicant> result = applicantRepository
+            List<FindApprovedApplicantsResult> result = applicantRepository
                 .findApprovedApplicants(recruitment.getRecruitmentId(),
                     shelter.getShelterId());
 
             // then
-            assertThat(result).isEqualTo(expected);
+            assertThat(result.size()).isEqualTo(expected.size());
         }
     }
 
@@ -197,7 +199,7 @@ class ApplicantRepositoryTest extends BaseRepositoryTest {
                 .containsExactly(
                     applicantShouldWriteReview1.getApplicantId(),
                     applicantShouldWriteReview2.getApplicantId()
-                    );
+                );
         }
     }
 

--- a/src/test/java/com/clova/anifriends/domain/applicant/support/ApplicantDtoFixture.java
+++ b/src/test/java/com/clova/anifriends/domain/applicant/support/ApplicantDtoFixture.java
@@ -2,6 +2,7 @@ package com.clova.anifriends.domain.applicant.support;
 
 import com.clova.anifriends.domain.applicant.repository.response.FindApplicantResult;
 import com.clova.anifriends.domain.applicant.repository.response.FindApplyingVolunteerResult;
+import com.clova.anifriends.domain.applicant.repository.response.FindApprovedApplicantsResult;
 import com.clova.anifriends.domain.applicant.vo.ApplicantStatus;
 import com.clova.anifriends.domain.volunteer.vo.VolunteerGender;
 import java.time.LocalDate;
@@ -26,6 +27,7 @@ public class ApplicantDtoFixture {
     private static final int COMPLETED_VOLUNTEER_COUNT = 5;
     private static final int VOLUNTEER_TEMPERATURE = 36;
     private static final String VOLUNTEER_NAME = "봉사자 이름";
+    private static final String VOLUNTEER_PHONE_NUMBER = "010-9827-1234";
 
     public static List<FindApplyingVolunteerResult> findApplyingVolunteerResults(int end) {
         return IntStream.range(0, end)
@@ -126,6 +128,48 @@ public class ApplicantDtoFixture {
             public ApplicantStatus getApplicantStatus() {
                 return APPLICANT_STATUS;
             }
+        };
+    }
+
+    public static FindApprovedApplicantsResult findApprovedApplicantsResult(
+        ApplicantStatus applicantStatus) {
+        return new FindApprovedApplicantsResult() {
+
+            @Override
+            public Long getVolunteerId() {
+                return VOLUNTEER_ID;
+            }
+
+            @Override
+            public Long getApplicantId() {
+                return APPLICANT_ID;
+            }
+
+            @Override
+            public String getVolunteerName() {
+                return VOLUNTEER_NAME;
+            }
+
+            @Override
+            public LocalDate getVolunteerBirthDate() {
+                return VOLUNTEER_BIRTH_DATE;
+            }
+
+            @Override
+            public VolunteerGender getVolunteerGender() {
+                return VOLUNTEER_GENDER;
+            }
+
+            @Override
+            public String getVolunteerPhoneNumber() {
+                return VOLUNTEER_PHONE_NUMBER;
+            }
+
+            @Override
+            public ApplicantStatus getApplicantStatus() {
+                return applicantStatus;
+            }
+
         };
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- `ApplicantRepository의 findApprovedApplicants` 쿼리를 `dto`에 맞게 변경 & 결과를 `List<FindApprovedApplicantsResult>`로 변경했습니다.
- `Applicant의 isAttendance`를 사용하지 못해서 `ApplicantMapper의 resultToResponse에서 검증`하는 로직을 적용했습니다. (해당 인자가 Applicant에서 FindApprovedApplicantsResult로 변경되었기 때문입니다.)
- ApplicantDtoFixture에 FindApprovedApplicantsResult를 추가했습니다.
- `봉사자, 보호소 프론트 url을 변경`했습니다.
- 이슈/해결 아카이빙의 n+1 개선기 findApplicantsApproved 부분 업데이트했습니다.

### 📝 작업 요약
- ApplicantRepository의 findApprovedApplicants 쿼리를 dto에 맞게 변경
- 봉사자, 보호소 프론트 url 변경

### 💡 관련 이슈
- close #398 
