### PR TITLE
refactor: 후원 API 중복 요청을 방지한다. (따닥 방지)

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/donation/exception/DonationDuplicateException.java
+++ b/src/main/java/com/clova/anifriends/domain/donation/exception/DonationDuplicateException.java
@@ -1,0 +1,11 @@
+package com.clova.anifriends.domain.donation.exception;
+
+import com.clova.anifriends.global.exception.BadRequestException;
+import com.clova.anifriends.global.exception.ErrorCode;
+
+public class DonationDuplicateException extends BadRequestException {
+
+    public DonationDuplicateException(String message) {
+        super(ErrorCode.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/donation/repository/DonationCacheRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/donation/repository/DonationCacheRepository.java
@@ -1,0 +1,6 @@
+package com.clova.anifriends.domain.donation.repository;
+
+public interface DonationCacheRepository {
+
+    boolean isDuplicateDonation(Long volunteerId);
+}

--- a/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
@@ -24,6 +24,7 @@ public class DonationRedisRepository implements DonationCacheRepository {
 
     public boolean isDuplicateDonation(Long volunteerId) {
         String key = "donation:" + volunteerId;
-        return !valueOperations.setIfAbsent(key, true, TIMEOUT, TimeUnit.SECONDS);
+        return Boolean.FALSE.equals(
+            valueOperations.setIfAbsent(key, true, TIMEOUT, TimeUnit.SECONDS));
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class DonationRedisRepository implements DonationCacheRepository {
 
     public static final int TIMEOUT = 1;
+    public static final String DONATION_KEY = "donation:";
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -23,7 +24,7 @@ public class DonationRedisRepository implements DonationCacheRepository {
     }
 
     public boolean isDuplicateDonation(Long volunteerId) {
-        String key = "donation:" + volunteerId;
+        String key = DONATION_KEY + volunteerId;
         return Boolean.FALSE.equals(
             valueOperations.setIfAbsent(key, true, TIMEOUT, TimeUnit.SECONDS));
     }

--- a/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
@@ -1,0 +1,29 @@
+package com.clova.anifriends.domain.donation.repository;
+
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DonationRedisRepository implements DonationCacheRepository {
+
+    public static final int TIMEOUT = 1;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private ValueOperations<String, Object> valueOperations;
+
+    @PostConstruct
+    public void init() {
+        valueOperations = redisTemplate.opsForValue();
+    }
+
+    public boolean isDuplicateDonation(Long volunteerId) {
+        String key = "donation:" + volunteerId;
+        return !valueOperations.setIfAbsent(key, true, TIMEOUT, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/donation/repository/DonationRedisRepository.java
@@ -1,26 +1,20 @@
 package com.clova.anifriends.domain.donation.repository;
 
-import jakarta.annotation.PostConstruct;
 import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RequiredArgsConstructor
 public class DonationRedisRepository implements DonationCacheRepository {
 
     public static final int TIMEOUT = 1;
     public static final String DONATION_KEY = "donation:";
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final ValueOperations<String, Object> valueOperations;
 
-    private ValueOperations<String, Object> valueOperations;
-
-    @PostConstruct
-    public void init() {
-        valueOperations = redisTemplate.opsForValue();
+    public DonationRedisRepository(RedisTemplate<String, Object> redisTemplate) {
+        this.valueOperations = redisTemplate.opsForValue();
     }
 
     public boolean isDuplicateDonation(Long volunteerId) {

--- a/src/test/java/com/clova/anifriends/base/DatabaseCleaner.java
+++ b/src/test/java/com/clova/anifriends/base/DatabaseCleaner.java
@@ -4,6 +4,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Table;
 import jakarta.persistence.metamodel.Type;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,9 @@ public class DatabaseCleaner {
 
     private final EntityManager entityManager;
     private final List<String> tableNames;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     public DatabaseCleaner(EntityManager em) {
         this.entityManager = em;
@@ -37,5 +42,7 @@ public class DatabaseCleaner {
 
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY true")
             .executeUpdate();
+
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
     }
 }

--- a/src/test/java/com/clova/anifriends/domain/donation/service/DonationIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/donation/service/DonationIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.clova.anifriends.domain.donation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.awaitility.Awaitility.await;
+
+import com.clova.anifriends.base.BaseIntegrationTest;
+import com.clova.anifriends.domain.donation.exception.DonationDuplicateException;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DonationIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private DonationService donationService;
+
+    @Nested
+    @DisplayName("registerDonation 실행 시")
+    class RegisterDonationTest {
+
+        @Test
+        @DisplayName("성공: 1초 간격으로 두 번 후원 요청 시")
+        void registerDonation() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            int amount = 100_000;
+
+            volunteerRepository.save(volunteer);
+            shelterRepository.save(shelter);
+
+            // when && then
+            donationService.registerDonation(volunteer.getVolunteerId(), shelter.getShelterId(),
+                amount);
+
+            await().pollDelay(Duration.ofSeconds(1)).untilAsserted(() -> {
+                assertThat(catchException(
+                    () -> donationService.registerDonation(volunteer.getVolunteerId(),
+                        shelter.getShelterId(), amount))).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("예외(DonationDuplicateException): 1초 안에 연속 두 번 후원 요청 시")
+        void exceptionWhenDuplicateDonation() {
+            // given
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Shelter shelter = ShelterFixture.shelter();
+            int amount = 100_000;
+
+            volunteerRepository.save(volunteer);
+            shelterRepository.save(shelter);
+
+            // when
+            Exception exception = catchException(() -> {
+                donationService.registerDonation(volunteer.getVolunteerId(), shelter.getShelterId(),
+                    amount);
+                donationService.registerDonation(volunteer.getVolunteerId(), shelter.getShelterId(),
+                    amount);
+            });
+
+            // then
+            assertThat(exception).isInstanceOf(DonationDuplicateException.class);
+        }
+
+    }
+
+}

--- a/src/test/java/com/clova/anifriends/domain/donation/service/DonationServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/donation/service/DonationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.clova.anifriends.domain.donation.Donation;
 import com.clova.anifriends.domain.donation.dto.response.PaymentRequestResponse;
+import com.clova.anifriends.domain.donation.repository.DonationCacheRepository;
 import com.clova.anifriends.domain.donation.support.fixture.DonationFixture;
 import com.clova.anifriends.domain.payment.Payment;
 import com.clova.anifriends.domain.payment.repository.PaymentRepository;
@@ -41,6 +42,9 @@ class DonationServiceTest {
     @Mock
     private PaymentRepository paymentRepository;
 
+    @Mock
+    private DonationCacheRepository donationCacheRepository;
+
     @Nested
     @DisplayName("registerDonation 실행 시")
     class RegisterDonationTest {
@@ -55,6 +59,8 @@ class DonationServiceTest {
             Payment payment = new Payment(donation);
             PaymentRequestResponse expected = PaymentRequestResponse.of(payment);
 
+            when(donationCacheRepository.isDuplicateDonation(anyLong())).thenReturn(
+                false);
             when(shelterRepository.findById(anyLong())).thenReturn(Optional.of(shelter));
             when(volunteerRepository.findById(anyLong())).thenReturn(Optional.of(volunteer));
 


### PR DESCRIPTION
### ⛏ 작업 사항
- Redis 의 String 자료구조와 TTL 을 사용하여 후원 API 중복 요청을 방지하였습니다.

### 📝 작업 요약
- 후원 API 요청 시 Redis 에 `donation:{volunteerId}` : `true` 저장
- TTL 을 1초로 설정하여 1초 후 저장한 값 삭제
- 1초 내의 중복 요청 시 `DonationDuplicateException` 발생
- 독립적인 테스트를 위해 `DatebaseCleaner` 에 Redis 초기화 수행

### 💡 관련 이슈
- close #446 
