### PR TITLE
fix: runtimeException 예외 메시지를 그대로 반환하는 문제를 수정한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clova/anifriends/global/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> runtimeEx(RuntimeException e) {
         return ResponseEntity.status(INTERNAL_SERVER_ERROR)
             .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR.getValue(),
-                "예측하지 못한 예외가 발생하였습니다." + e.getMessage()));
+                "예측하지 못한 예외가 발생하였습니다."));
     }
 
     @ExceptionHandler(BadRequestException.class)


### PR DESCRIPTION
### ⛏ 작업 사항
- runtimeException 예외 핸들러에서 예외 메시지를 사용자에게 반환하는 문제가 있었습니다.
- 메시지를 반환하는 코드를 삭제해 해당 취약점을 제거하였습니다.

### 📝 작업 요약
- runtimeException 예외 핸들러 수정

### 💡 관련 이슈
- #449 
