### PR TITLE
fix: runtimeException 예외 메시지를 그대로 반환하는 문제를 수정한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clova/anifriends/global/exception/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> runtimeEx(RuntimeException e) {
         return ResponseEntity.status(INTERNAL_SERVER_ERROR)
             .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR.getValue(),
-                "예측하지 못한 예외가 발생하였습니다." + e.getMessage()));
+                "예측하지 못한 예외가 발생하였습니다."));
     }
 
     @ExceptionHandler(BadRequestException.class)


### PR DESCRIPTION
### ⛏ 작업 사항
- runtimeException 예외 핸들러에서 예외 메시지를 포함한 응답을 반환하지 않도록 수정하였습니다.
- 다른 pr에서 dev 브랜치에 반영하겠습니다.

### 📝 작업 요약
- runtimeException 예외 핸들러 수정

### 💡 관련 이슈
- #449 
