### PR TITLE
refactor: 봉사자의 후원금 결제 확인을 위한 PG API 호출을 트랜잭션에서 분리한다.

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/payment/repository/PaymentRepository.java
@@ -1,10 +1,32 @@
 package com.clova.anifriends.domain.payment.repository;
 
 import com.clova.anifriends.domain.payment.Payment;
+import com.clova.anifriends.domain.payment.vo.PaymentStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByOrderId(String orderId);
+
+    @Modifying
+    @Transactional
+    @Query("update Payment p set p.status = :status where p.paymentId = :paymentId")
+    void updatePaymentStatus(
+        @Param("paymentId") Long paymentId,
+        @Param("status") PaymentStatus status
+    );
+
+    @Modifying
+    @Transactional
+    @Query("update Payment p set p.paymentKey = :paymentKey, p.status = :status where p.paymentId = :paymentId")
+    void updatePaymentKeyAndStatus(
+        @Param("paymentId") Long paymentId,
+        @Param("paymentKey") String paymentKey,
+        @Param("status") PaymentStatus status
+    );
 }

--- a/src/test/java/com/clova/anifriends/base/BaseRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/base/BaseRepositoryTest.java
@@ -5,8 +5,10 @@ import com.clova.anifriends.domain.animal.repository.AnimalRepository;
 import com.clova.anifriends.domain.applicant.repository.ApplicantRepository;
 import com.clova.anifriends.domain.chat.repository.ChatMessageRepository;
 import com.clova.anifriends.domain.chat.repository.ChatRoomRepository;
+import com.clova.anifriends.domain.donation.repository.DonationRepository;
 import com.clova.anifriends.domain.notification.repository.ShelterNotificationRepository;
 import com.clova.anifriends.domain.notification.repository.VolunteerNotificationRepository;
+import com.clova.anifriends.domain.payment.repository.PaymentRepository;
 import com.clova.anifriends.domain.recruitment.repository.RecruitmentRepository;
 import com.clova.anifriends.domain.review.repository.ReviewRepository;
 import com.clova.anifriends.domain.shelter.repository.ShelterRepository;
@@ -53,4 +55,10 @@ public abstract class BaseRepositoryTest {
 
     @Autowired
     protected VolunteerNotificationRepository volunteerNotificationRepository;
+
+    @Autowired
+    protected PaymentRepository paymentRepository;
+
+    @Autowired
+    protected DonationRepository donationRepository;
 }

--- a/src/test/java/com/clova/anifriends/domain/payment/repository/PaymentRepositoryTest.java
+++ b/src/test/java/com/clova/anifriends/domain/payment/repository/PaymentRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.clova.anifriends.domain.payment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.clova.anifriends.base.BaseRepositoryTest;
+import com.clova.anifriends.domain.donation.Donation;
+import com.clova.anifriends.domain.donation.support.fixture.DonationFixture;
+import com.clova.anifriends.domain.payment.Payment;
+import com.clova.anifriends.domain.payment.vo.PaymentStatus;
+import com.clova.anifriends.domain.shelter.Shelter;
+import com.clova.anifriends.domain.shelter.support.ShelterFixture;
+import com.clova.anifriends.domain.volunteer.Volunteer;
+import com.clova.anifriends.domain.volunteer.support.VolunteerFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PaymentRepositoryTest extends BaseRepositoryTest {
+
+    @Nested
+    @DisplayName("updatePaymentStatus 실행 시")
+    class UpdatePaymentStatusTest {
+
+        @Test
+        @DisplayName("성공")
+        void updatePaymentStatus() {
+            // given
+            Shelter shelter = ShelterFixture.shelter();
+            Volunteer volunteer = VolunteerFixture.volunteer();
+            Donation donation = DonationFixture.donation(shelter, volunteer);
+            Payment payment = new Payment(donation);
+
+            shelterRepository.save(shelter);
+            volunteerRepository.save(volunteer);
+            paymentRepository.save(payment);
+
+            // when
+            paymentRepository.updatePaymentStatus(payment.getPaymentId(), PaymentStatus.ABORTED);
+
+            // then
+            entityManager.flush();
+            entityManager.clear();
+
+            Payment updatedPayment = paymentRepository.findById(payment.getPaymentId()).get();
+            assertThat(updatedPayment.getStatus()).isEqualTo(PaymentStatus.ABORTED);
+        }
+    }
+
+}

--- a/src/test/java/com/clova/anifriends/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/payment/service/PaymentServiceTest.java
@@ -68,8 +68,6 @@ class PaymentServiceTest {
             // then
             verify(paymentClient, times(1)).confirmPayment(orderId, paymentKey, amount);
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
-            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.DONE);
-            assertThat(payment.getPaymentKey()).isEqualTo(paymentKey);
         }
 
         @Test


### PR DESCRIPTION
### ⛏ 작업 사항
- 봉사자의 후원금 결제 확인을 위한 PG API 호출을 트랜잭션에서 분리했습니다.

### 📝 작업 요약
기존 방식은 다음과 같은 로직이 하나의 트랜잭션에서 진행되었습니다.
1. `Payment` 를 조회해서 결제 상태와 결제 금액을 확인
2. PG API 와 통신하여 결제를 확인
3. 결제 상태를 갱신하는 로직

`paymentSuccess` 메소드의 `Transactional` 애노테이션을 제거하여 각각의 분리된 트랜잭션에서 진행하도록 수정하였고, PG API 와 통신하는 로직을 트랜잭션 외부에서 동작하도록 수정하였습니다.

### 💡 관련 이슈
- close #435 
