### PR TITLE
refactor: 봉사 모집글 목록 조회 캐시를 개선한다. 

### DIFF
--- a/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/dto/response/FindRecruitmentsResponse.java
@@ -11,12 +11,6 @@ public record FindRecruitmentsResponse(
     List<FindRecruitmentResponse> recruitments,
     PageInfo pageInfo) {
 
-    public static FindRecruitmentsResponse fromCached(
-        Slice<FindRecruitmentResponse> cachedRecruitments, Long count) {
-        PageInfo pageInfo = PageInfo.of(count, cachedRecruitments.hasNext());
-        return new FindRecruitmentsResponse(cachedRecruitments.getContent(), pageInfo);
-    }
-
     public record FindRecruitmentResponse(
         Long recruitmentId,
         String recruitmentTitle,

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentCacheRepository.java
@@ -1,27 +1,17 @@
 package com.clova.anifriends.domain.recruitment.repository;
 
 import com.clova.anifriends.domain.recruitment.Recruitment;
-import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse;
 
 public interface RecruitmentCacheRepository {
 
+    long getTotalNumberOfRecruitments();
+
     void saveRecruitment(Recruitment recruitment);
 
-    Slice<FindRecruitmentResponse> findRecruitments(Pageable pageable);
+    long deleteRecruitment(Recruitment recruitment);
 
-    void updateRecruitment(Recruitment recruitment);
-
-    void deleteRecruitment(Recruitment recruitment);
+    FindRecruitmentsResponse findRecruitments(int size);
 
     void closeRecruitmentsIfNeedToBe();
-
-    Long getRecruitmentCount();
-
-    void saveRecruitmentCount(Long count);
-
-    void increaseRecruitmentCount();
-
-    void decreaseToRecruitmentCount();
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRedisRepository.java
@@ -59,7 +59,7 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
     }
 
     private void trimCache() {
-        cachedRecruitments.removeRange(RECRUITMENT_KEY, 0, -MAX_CACHED_SIZE - 1);
+        cachedRecruitments.removeRange(RECRUITMENT_KEY, ZERO, -MAX_CACHED_SIZE - 1L);
     }
 
     /**
@@ -71,7 +71,7 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
     @Override
     public FindRecruitmentsResponse findRecruitments(int size) {
         Set<FindRecruitmentResponse> recruitments = Objects.requireNonNull(
-            cachedRecruitments.reverseRange(RECRUITMENT_KEY, ZERO, size - 1));
+            cachedRecruitments.reverseRange(RECRUITMENT_KEY, ZERO, size - 1L));
         long count = getTotalNumberOfRecruitments();
         PageInfo pageInfo = PageInfo.of(count, count > size);
         if (recruitments.size() >= size) {

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRedisRepository.java
@@ -59,13 +59,7 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
     }
 
     private void trimCache() {
-        Set<FindRecruitmentResponse> recruitments
-            = cachedRecruitments.range(RECRUITMENT_KEY, ZERO, UNTIL_LAST_ELEMENT);
-        if (Objects.nonNull(recruitments)) {
-            int needToRemoveSize = recruitments.size() - MAX_CACHED_SIZE;
-            needToRemoveSize = Math.max(needToRemoveSize, ZERO);
-            cachedRecruitments.popMin(RECRUITMENT_KEY, needToRemoveSize);
-        }
+        cachedRecruitments.removeRange(RECRUITMENT_KEY, 0, -MAX_CACHED_SIZE - 1);
     }
 
     /**
@@ -101,6 +95,7 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
 
     /**
      * 캐시된 봉사 모집글을 제거하고 카운트를 감소시킵니다.
+     *
      * @param recruitment
      * @return
      */

--- a/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRedisRepository.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/repository/RecruitmentRedisRepository.java
@@ -1,6 +1,8 @@
 package com.clova.anifriends.domain.recruitment.repository;
 
+import com.clova.anifriends.domain.common.PageInfo;
 import com.clova.anifriends.domain.recruitment.Recruitment;
+import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse;
 import com.clova.anifriends.domain.recruitment.dto.response.FindRecruitmentsResponse.FindRecruitmentResponse;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -8,11 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -24,10 +24,7 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
     private static final String RECRUITMENT_KEY = "recruitment";
     private static final String RECRUITMENT_COUNT_KEY = "recruitment:count";
     private static final int UNTIL_LAST_ELEMENT = -1;
-    private static final Long RECRUITMENT_COUNT_NO_CACHE = -1L;
-    private static final Long COUNT_ONE = 1L;
     private static final int MAX_CACHED_SIZE = 30;
-    private static final int PAGE_SIZE = 20;
     private static final int ZERO = 0;
     public static final ZoneOffset CREATED_AT_SCORE_TIME_ZONE = ZoneOffset.UTC;
 
@@ -43,16 +40,25 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
         this.recruitmentRepository = recruitmentRepository;
     }
 
+    /**
+     * 봉사 모집글을 캐시에 저장하고 캐싱된 카운트를 증가시킵니다.
+     *
+     * @param recruitment
+     */
     @Override
     public void saveRecruitment(final Recruitment recruitment) {
         FindRecruitmentResponse recruitmentResponse = FindRecruitmentResponse.from(recruitment);
         long createdAtScore = getCreatedAtScore(recruitment);
         cachedRecruitments.add(RECRUITMENT_KEY, recruitmentResponse, createdAtScore);
-
-        popUntilCachedSize();
+        cachedRecruitmentsCount.increment(RECRUITMENT_COUNT_KEY);
+        trimCache();
     }
 
-    private void popUntilCachedSize() {
+    private long getCreatedAtScore(Recruitment recruitment) {
+        return recruitment.getCreatedAt().toEpochSecond(CREATED_AT_SCORE_TIME_ZONE);
+    }
+
+    private void trimCache() {
         Set<FindRecruitmentResponse> recruitments
             = cachedRecruitments.range(RECRUITMENT_KEY, ZERO, UNTIL_LAST_ELEMENT);
         if (Objects.nonNull(recruitments)) {
@@ -63,69 +69,58 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
     }
 
     /**
-     * 캐시된 Recruitment dto 리스트를 size만큼 조회합니다. size가 지정된 최대 size를 초과하는 경우 지정된 최대 size만큼 조회해옵니다.
+     * 캐시된 Recruitment dto 리스트를 첫번째 요소부터 size만큼 조회합니다. size가 최대 캐싱 사이즈를 초과하는 경우 db에서 조회합니다.
      *
-     * @param pageable 조회해 올 리스트 pageable. 최대 사이즈 20
-     * @return 캐시된 Recruitment dto 리스트
+     * @param size 조회할 사이즈
+     * @return FindRecruitmentsResponse 캐시 혹은 db에서 조회한 결과
      */
     @Override
-    public Slice<FindRecruitmentResponse> findRecruitments(Pageable pageable) {
-        long size = pageable.getPageSize();
-        if (size > PAGE_SIZE) {
-            size = PAGE_SIZE;
+    public FindRecruitmentsResponse findRecruitments(int size) {
+        Set<FindRecruitmentResponse> recruitments = Objects.requireNonNull(
+            cachedRecruitments.reverseRange(RECRUITMENT_KEY, ZERO, size - 1));
+        long count = getTotalNumberOfRecruitments();
+        PageInfo pageInfo = PageInfo.of(count, count > size);
+        if (recruitments.size() >= size) {
+            List<FindRecruitmentResponse> content = recruitments.stream()
+                .limit(size)
+                .toList();
+            return new FindRecruitmentsResponse(content, pageInfo);
         }
-        Set<FindRecruitmentResponse> recruitments
-            = cachedRecruitments.reverseRange(RECRUITMENT_KEY, ZERO, size);
-        if (Objects.isNull(recruitments)) {
-            return new SliceImpl<>(List.of());
-        }
-        List<FindRecruitmentResponse> content = recruitments.stream()
-            .limit(size)
+
+        PageRequest pageRequest = PageRequest.of(ZERO, size);
+        List<FindRecruitmentResponse> content = getRecruitmentsV2(pageRequest)
+            .map(FindRecruitmentResponse::from)
             .toList();
-        boolean hasNext = recruitments.size() > size;
-        return new SliceImpl<>(content, pageable, hasNext);
+        return new FindRecruitmentsResponse(content, pageInfo);
     }
 
+    private Slice<Recruitment> getRecruitmentsV2(PageRequest pageRequest) {
+        return recruitmentRepository.findRecruitmentsV2(null, null,
+            null, null, null, null, null, pageRequest);
+    }
+
+    /**
+     * 캐시된 봉사 모집글을 제거하고 카운트를 감소시킵니다.
+     * @param recruitment
+     * @return
+     */
     @Override
-    public void updateRecruitment(final Recruitment recruitment) {
-        long createdAtScore = getCreatedAtScore(recruitment);
-        Set<FindRecruitmentResponse> recruitments = cachedRecruitments.rangeByScore(
-            RECRUITMENT_KEY, createdAtScore, createdAtScore);
-        if (Objects.nonNull(recruitments)) {
-            Optional<FindRecruitmentResponse> oldCachedRecruitment = recruitments.stream()
-                .filter(findRecruitmentResponse -> isEqualsId(recruitment, findRecruitmentResponse))
-                .findFirst();
-            oldCachedRecruitment.ifPresent(oldRecruitment -> {
-                cachedRecruitments.remove(RECRUITMENT_KEY, oldRecruitment);
-                FindRecruitmentResponse updatedRecruitment
-                    = FindRecruitmentResponse.from(recruitment);
-                cachedRecruitments.add(RECRUITMENT_KEY, updatedRecruitment, createdAtScore);
-            });
-        }
-    }
-
-    private long getCreatedAtScore(Recruitment recruitment) {
-        return recruitment.getCreatedAt().toEpochSecond(CREATED_AT_SCORE_TIME_ZONE);
-    }
-
-    private boolean isEqualsId(
-        Recruitment recruitment,
-        FindRecruitmentResponse findRecruitmentResponse) {
-        return findRecruitmentResponse.recruitmentId().equals(recruitment.getRecruitmentId());
-    }
-
-    @Override
-    public void deleteRecruitment(final Recruitment recruitment) {
+    public long deleteRecruitment(final Recruitment recruitment) {
         FindRecruitmentResponse recruitmentResponse = FindRecruitmentResponse.from(recruitment);
-        cachedRecruitments.remove(RECRUITMENT_KEY, recruitmentResponse);
+        Long number = cachedRecruitments.remove(RECRUITMENT_KEY, recruitmentResponse);
+        cachedRecruitmentsCount.decrement(RECRUITMENT_COUNT_KEY);
+        return Objects.isNull(number) ? 0 : number;
     }
 
+    /**
+     * 캐시된 봉사 모집글 중 모집 기간이 종료된 요소를 업데이트합니다.
+     */
     @Override
     public void closeRecruitmentsIfNeedToBe() {
         LocalDateTime now = LocalDateTime.now();
         Set<FindRecruitmentResponse> findRecruitments = cachedRecruitments.range(RECRUITMENT_KEY,
             ZERO, UNTIL_LAST_ELEMENT);
-        if(Objects.nonNull(findRecruitments)) {
+        if (Objects.nonNull(findRecruitments)) {
             Map<FindRecruitmentResponse, FindRecruitmentResponse> cachedKeyAndUpdatedValue
                 = new HashMap<>();
             findRecruitments.stream()
@@ -169,50 +164,13 @@ public class RecruitmentRedisRepository implements RecruitmentCacheRepository {
     }
 
     @Override
-    public Long getRecruitmentCount() {
+    public long getTotalNumberOfRecruitments() {
         Object cachedCount = cachedRecruitmentsCount.get(RECRUITMENT_COUNT_KEY);
-
-        if (Objects.isNull(cachedCount)) {
-            return RECRUITMENT_COUNT_NO_CACHE;
-        }
-
-        if (cachedCount instanceof Long) {
-            return (Long) cachedCount;
-        } else {
+        if (Objects.nonNull(cachedCount)) {
             return ((Integer) cachedCount).longValue();
         }
-    }
-
-    @Override
-    public void saveRecruitmentCount(
-        Long count
-    ) {
-        cachedRecruitmentsCount.set(RECRUITMENT_COUNT_KEY, count);
-    }
-
-    @Override
-    public void increaseRecruitmentCount() {
-        Object cachedCount = cachedRecruitmentsCount.get(RECRUITMENT_COUNT_KEY);
-
-        if (Objects.nonNull(cachedCount)) {
-            saveRecruitmentCount((Integer) cachedCount + COUNT_ONE);
-        }
-
-        long dbRecruitmentCount = recruitmentRepository.count();
-
-        saveRecruitmentCount(dbRecruitmentCount);
-    }
-
-    @Override
-    public void decreaseToRecruitmentCount() {
-        Object cachedCount = cachedRecruitmentsCount.get(RECRUITMENT_COUNT_KEY);
-
-        if (Objects.nonNull(cachedCount)) {
-            saveRecruitmentCount((Integer) cachedCount - COUNT_ONE);
-        }
-
-        long dbRecruitmentCount = recruitmentRepository.count();
-
-        saveRecruitmentCount(dbRecruitmentCount);
+        long dbCount = recruitmentRepository.count();
+        cachedRecruitmentsCount.set(RECRUITMENT_COUNT_KEY, dbCount);
+        return dbCount;
     }
 }

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -173,9 +173,11 @@ public class RecruitmentService {
     @Transactional
     public void closeRecruitment(Long shelterId, Long recruitmentId) {
         Recruitment recruitment = getRecruitmentByShelter(shelterId, recruitmentId);
-        recruitmentCacheRepository.deleteRecruitment(recruitment);
+        long deleted = recruitmentCacheRepository.deleteRecruitment(recruitment);
         recruitment.closeRecruitment();
-        recruitmentCacheRepository.saveRecruitment(recruitment);
+        if(deleted > 0) {
+            recruitmentCacheRepository.saveRecruitment(recruitment);
+        }
     }
 
     @Transactional
@@ -191,7 +193,7 @@ public class RecruitmentService {
         List<String> imageUrls
     ) {
         Recruitment recruitment = getRecruitmentByShelterWithImages(shelterId, recruitmentId);
-        recruitmentCacheRepository.deleteRecruitment(recruitment);
+        long deleted = recruitmentCacheRepository.deleteRecruitment(recruitment);
 
         List<String> imagesToDelete = recruitment.findImagesToDelete(imageUrls);
         applicationEventPublisher.publishEvent(new ImageDeletionEvent(imagesToDelete));
@@ -205,7 +207,9 @@ public class RecruitmentService {
             content,
             imageUrls
         );
-        recruitmentCacheRepository.saveRecruitment(recruitment);
+        if(deleted > 0) {
+            recruitmentCacheRepository.saveRecruitment(recruitment);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/clova/anifriends/domain/recruitment/service/RecruitmentService.java
@@ -141,8 +141,7 @@ public class RecruitmentService {
         Pageable pageable
     ) {
         if (isFirstPage(keyword, startDate, endDate, isClosed, keywordCondition, recruitmentId)) {
-            return recruitmentCacheRepository.findRecruitments(pageable.getPageSize()
-            );
+            return recruitmentCacheRepository.findRecruitments(pageable.getPageSize());
         }
 
         long count = recruitmentRepository.countFindRecruitmentsV2(

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentIntegrationTest.java
@@ -63,6 +63,8 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
             shelterRepository.save(shelter);
             recruitmentRepository.save(recruitment);
+            recruitmentCacheRepository.saveRecruitment(recruitment);
+            long count = recruitmentCacheRepository.getTotalNumberOfRecruitments();
 
             // when
             recruitmentService.registerRecruitment(
@@ -77,8 +79,8 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
             );
 
             // then
-            assertThat(recruitmentRepository.count()).isEqualTo(
-                recruitmentCacheRepository.getRecruitmentCount());
+            assertThat(recruitmentCacheRepository.getTotalNumberOfRecruitments())
+                .isEqualTo(count + 1);
         }
     }
 
@@ -179,6 +181,7 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
             // given
             Recruitment recruitment = RecruitmentFixture.recruitment(shelter);
             Recruitment savedRecruitment = recruitmentRepository.save(recruitment);
+            long count = recruitmentCacheRepository.getTotalNumberOfRecruitments();
 
             // when
             recruitmentService.deleteRecruitment(
@@ -188,7 +191,7 @@ public class RecruitmentIntegrationTest extends BaseIntegrationTest {
 
             // then
             assertThat(recruitmentRepository.count()).isEqualTo(
-                recruitmentCacheRepository.getRecruitmentCount());
+                recruitmentCacheRepository.getTotalNumberOfRecruitments());
         }
     }
 

--- a/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/clova/anifriends/domain/recruitment/service/RecruitmentServiceTest.java
@@ -516,6 +516,40 @@ class RecruitmentServiceTest {
             //then
             assertThat(exception).isInstanceOf(RecruitmentNotFoundException.class);
         }
+
+        @Test
+        @DisplayName("성공: 캐시 되어있던 봉사 모집글이 아니면 캐시 추가를 호출하지 않는다.")
+        void doesNotInvokeCacheSave_WhenNotExistsInCache() {
+            //given
+            given(recruitmentRepository.findByShelterIdAndRecruitmentId(anyLong(), anyLong()))
+                .willReturn(Optional.ofNullable(recruitment));
+            given(recruitmentCacheRepository.deleteRecruitment(any()))
+                .willReturn(0L);
+
+            //when
+            recruitmentService.closeRecruitment(1L, 1L);
+
+            //then
+            then(recruitmentCacheRepository).should(times(0))
+                .saveRecruitment(any());
+        }
+
+        @Test
+        @DisplayName("성공: 캐시 되어있던 봉사 모집글이면 캐시 추가를 호출한다.")
+        void invokeCacheSave_WhenExistsInCache() {
+            //given
+            given(recruitmentRepository.findByShelterIdAndRecruitmentId(anyLong(), anyLong()))
+                .willReturn(Optional.ofNullable(recruitment));
+            given(recruitmentCacheRepository.deleteRecruitment(any()))
+                .willReturn(1L);
+
+            //when
+            recruitmentService.closeRecruitment(1L, 1L);
+
+            //then
+            then(recruitmentCacheRepository).should(times(1)).
+                saveRecruitment(any());
+        }
     }
 
     @Nested
@@ -586,6 +620,56 @@ class RecruitmentServiceTest {
 
             //then
             assertThat(exception).isInstanceOf(RecruitmentNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("성공: 캐시 되어있던 봉사 모집글이 아니면 캐시 추가를 호출하지 않는다.")
+        void doesNotInvokeCacheSave_WhenNotExistsInCache() {
+            //given
+            String newTitle = recruitment.getTitle() + "a";
+            LocalDateTime newStartTime = recruitment.getStartTime().plusDays(1);
+            LocalDateTime newEndTime = recruitment.getEndTime().plusDays(1);
+            LocalDateTime newDeadline = recruitment.getDeadline().plusDays(1);
+            int newCapacity = recruitment.getCapacity() + 1;
+            String newContent = recruitment.getContent() + "a";
+            List<String> newImageUrls = List.of("a1", "a2");
+
+            given(recruitmentRepository.findByShelterIdAndRecruitmentIdWithImages(anyLong(),
+                anyLong())).willReturn(Optional.ofNullable(recruitment));
+            given(recruitmentCacheRepository.deleteRecruitment(any())).willReturn(0L);
+
+            //when
+            recruitmentService.updateRecruitment(1L, 1L,
+                newTitle, newStartTime, newEndTime, newDeadline, newCapacity, newContent,
+                newImageUrls);
+
+            //then
+            then(recruitmentCacheRepository).should(times(0)).saveRecruitment(any());
+        }
+
+        @Test
+        @DisplayName("성공: 캐시 되어있던 봉사 모집글이면 캐시 추가를 호출한다.")
+        void invokeCacheSave_WhenExistsInCache() {
+            //given
+            String newTitle = recruitment.getTitle() + "a";
+            LocalDateTime newStartTime = recruitment.getStartTime().plusDays(1);
+            LocalDateTime newEndTime = recruitment.getEndTime().plusDays(1);
+            LocalDateTime newDeadline = recruitment.getDeadline().plusDays(1);
+            int newCapacity = recruitment.getCapacity() + 1;
+            String newContent = recruitment.getContent() + "a";
+            List<String> newImageUrls = List.of("a1", "a2");
+
+            given(recruitmentRepository.findByShelterIdAndRecruitmentIdWithImages(anyLong(),
+                anyLong())).willReturn(Optional.ofNullable(recruitment));
+            given(recruitmentCacheRepository.deleteRecruitment(any())).willReturn(1L);
+
+            //when
+            recruitmentService.updateRecruitment(1L, 1L,
+                newTitle, newStartTime, newEndTime, newDeadline, newCapacity, newContent,
+                newImageUrls);
+
+            //then
+            then(recruitmentCacheRepository).should(times(1)).saveRecruitment(any());
         }
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 보호 동물 목록 조회 개선 사항을 참고하여 봉사 모집글 목록 조회 캐싱을 수정했습니다.
  - 업데이트 로직 수정
    - 기존에 복잡했던 캐싱된 봉사 모집글 업데이트 로직을 제거하고 서비스 로직에서 `캐싱된 봉사 모집글 제거` -> `업데이트된 봉사 모집글 캐시에 저장`과 같이 직관적인 구성으로 변경하였습니다.
  - 동시성 이슈 수정
    - 봉사 모집글 저장 시 `캐시에서 조회` -> `최대 캐시 크기보다 크면 제거`로 로직이 이루어진 탓에 동시성 이슈가 발생하고 있었습니다. 해당 로직을 `일정 범위만큼 제거(removeRange(KEY, 0, -MAX_CACHE_SIZE-1))`로 원자적인 연산이 이루어지도록 변경하였습니다.
  - 메서드 이름 및 로직을 보호 동물 캐시 리포지토리와 유사하게 변경
    - 전체적인 메서드 이름을 보호 동물 캐시 리포지토리와 유사하게 변경하였습니다.
    - 로직 동작 방식 또한 유사하게 변경하였습니다.
  - 캐시 미스 시 동작을 수정
    - 기존에는 캐시 미스 시 동작을 서비스 로직에서 결정하고 있었으나 해당 동작을 모두 캐시 리포지토리 안으로 이동시켰습니다.
    - 조건이 존재하지 않는 조회의 경우 항상 캐시 리포지토리를 경유합니다. 
      - 입력된 사이즈가 최대 캐시 크기 이하인 경우에는 캐시 히트입니다. 
      - 입력된 사이즈가 최대 캐시 크기를 초과하는 경우에는 캐시 미스입니다.

### 📝 작업 요약
- 봉사 모집글 목록 조회 캐시 로직을 개선했습니다.

### 💡 관련 이슈
- close #460 
